### PR TITLE
fix: Printing `BindDirective` when is a shorthand

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,11 +4,7 @@
 	"version": "0.2.2",
 	"type": "module",
 	"description": "Print Svelte AST nodes as a string. Aka parse in reverse.",
-	"keywords": [
-		"svelte",
-		"ast",
-		"print"
-	],
+	"keywords": ["svelte", "ast", "print"],
 	"license": "MIT",
 	"author": {
 		"name": "Mateusz Kadlubowski",
@@ -37,10 +33,7 @@
 	"engines": {
 		"node": ">=20"
 	},
-	"files": [
-		"src/",
-		"types/"
-	],
+	"files": ["src/", "types/"],
 	"imports": {
 		"#tests/*": {
 			"types": "./tests/*.ts",

--- a/src/mod.js
+++ b/src/mod.js
@@ -577,9 +577,14 @@ class Printer {
 			/**
 			 * @see {@link https://svelte.dev/docs/element-directives#bind-property}
 			 *
-			 * @example pattern
+			 * @example default pattern
 			 * ```svelte
 			 * bind:property={variable}
+			 * ```
+			 *
+			 * @example shorthand - when variable name is same as property
+			 * ```svelte
+			 * bind:property
 			 * ```
 			 */
 			BindDirective(node, context) {

--- a/src/mod.js
+++ b/src/mod.js
@@ -585,13 +585,16 @@ class Printer {
 			BindDirective(node, context) {
 				const { name, expression } = node;
 				const { state } = context;
+				const is_shorthand = expression?.type === "Identifier" && expression.name === name;
 				let stringified = "bind";
 				stringified += ":";
 				stringified += name;
-				stringified += "=";
-				stringified += "{";
-				stringified += print_es(expression).code;
-				stringified += "}";
+				if (!is_shorthand) {
+					stringified += "=";
+					stringified += "{";
+					stringified += print_es(expression).code;
+					stringified += "}";
+				}
 				state.#attributes.add(stringified);
 			},
 

--- a/tests/nodes/directive.test.ts
+++ b/tests/nodes/directive.test.ts
@@ -36,7 +36,19 @@ describe("AnimateDirective", () => {
 	});
 });
 
-describe("BindDIrective", () => {
+describe("BindDirective", () => {
+	it("prints correctly when is a shorthand", ({ expect }) => {
+		const code = `
+			<script lang="ts">
+				let value: string;
+			</script>
+
+			<input type="text" bind:value />
+		`;
+		const node = parse_and_extract_svelte_node<BindDirective>(code, "BindDirective");
+		expect(print(node)).toMatchInlineSnapshot(`"bind:value"`);
+	});
+
 	it("works on binding input value", ({ expect }) => {
 		const code = `
 			<input bind:value={name} />

--- a/tests/nodes/element-like.test.ts
+++ b/tests/nodes/element-like.test.ts
@@ -32,7 +32,7 @@ describe("Component", () => {
 		`;
 		const node = parse_and_extract_svelte_node<Component>(code, "Component");
 		expect(print(node)).toMatchInlineSnapshot(
-			`"<Slider bind:value={value} min={0} --rail-color="black" --track-color="rgb(0, 0, 255)" />"`,
+			`"<Slider bind:value min={0} --rail-color="black" --track-color="rgb(0, 0, 255)" />"`,
 		);
 	});
 
@@ -98,7 +98,7 @@ describe("RegularElement", () => {
 		`;
 		const node = parse_and_extract_svelte_node<RegularElement>(code, "RegularElement");
 		expect(print(node)).toMatchInlineSnapshot(
-			`"<input bind:value={value} min={0} style:--rail-color="black" style:--track-color="rgb(0, 0, 255)" />"`,
+			`"<input bind:value min={0} style:--rail-color="black" style:--track-color="rgb(0, 0, 255)" />"`,
 		);
 	});
 


### PR DESCRIPTION

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>0.2.3--canary.84.9875062767.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install svelte-ast-print@0.2.3--canary.84.9875062767.0
  # or 
  yarn add svelte-ast-print@0.2.3--canary.84.9875062767.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
