### PR TITLE
feat: typescript

### DIFF
--- a/package.json
+++ b/package.json
@@ -84,7 +84,6 @@
 		"test": "vitest run . --passWithNoTests"
 	},
 	"dependencies": {
-		"@babel/parser": "^7.25.0",
 		"recast": "^0.23.9",
 		"zimmerframe": "1.1.2"
 	},

--- a/package.json
+++ b/package.json
@@ -84,7 +84,8 @@
 		"test": "vitest run . --passWithNoTests"
 	},
 	"dependencies": {
-		"esrap": "1.2.2",
+		"@babel/parser": "^7.25.0",
+		"recast": "^0.23.9",
 		"zimmerframe": "1.1.2"
 	},
 	"devDependencies": {

--- a/package.json
+++ b/package.json
@@ -121,5 +121,10 @@
 		"typedoc-plugin-coverage": "3.3.0",
 		"typedoc-plugin-mdn-links": "3.2.2",
 		"vitest": "2.0.2"
+	},
+	"pnpm": {
+		"patchedDependencies": {
+			"recast@0.23.9": "patches/recast@0.23.9.patch"
+		}
 	}
 }

--- a/patches/recast@0.23.9.patch
+++ b/patches/recast@0.23.9.patch
@@ -1,0 +1,31 @@
+diff --git a/lib/printer.js b/lib/printer.js
+index 2fcefa18d060e71489f6a480bf2f976651368e0a..f9660e28a8a4e88fae09acc791358a04cb1c087e 100644
+--- a/lib/printer.js
++++ b/lib/printer.js
+@@ -532,7 +532,7 @@ function genericPrintNoParens(path, options, print) {
+             fields.forEach(function (field) {
+                 len_1 += n[field].length;
+             });
+-            var oneLine_1 = (isTypeAnnotation_1 && len_1 === 1) || len_1 === 0;
++            var oneLine_1 = true;
+             var leftBrace = n.exact ? "{|" : "{";
+             var rightBrace = n.exact ? "|}" : "}";
+             parts.push(oneLine_1 ? leftBrace : leftBrace + "\n");
+@@ -544,7 +544,7 @@ function genericPrintNoParens(path, options, print) {
+                     if (!oneLine_1) {
+                         lines = lines.indent(options.tabWidth);
+                     }
+-                    var multiLine = !isTypeAnnotation_1 && lines.length > 1;
++                    var multiLine = false;
+                     if (multiLine && allowBreak_1) {
+                         // Similar to the logic for BlockStatement.
+                         parts.push("\n");
+@@ -553,7 +553,7 @@ function genericPrintNoParens(path, options, print) {
+                     if (i_1 < len_1 - 1) {
+                         // Add an extra line break if the previous object property
+                         // had a multi-line value.
+-                        parts.push(separator_1 + (multiLine ? "\n\n" : "\n"));
++                        parts.push(separator_1 + (multiLine ? "\n\n" : " "));
+                         allowBreak_1 = !multiLine;
+                     }
+                     else if (len_1 !== 1 && isTypeAnnotation_1) {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,9 +8,12 @@ importers:
 
   .:
     dependencies:
-      esrap:
-        specifier: 1.2.2
-        version: 1.2.2
+      '@babel/parser':
+        specifier: ^7.25.0
+        version: 7.25.0
+      recast:
+        specifier: ^0.23.9
+        version: 0.23.9
       zimmerframe:
         specifier: 1.1.2
         version: 1.1.2
@@ -50,7 +53,7 @@ importers:
         version: 5.1.0
       lefthook:
         specifier: 1.6.18
-        version: 1.7.1
+        version: 1.6.18
       markdownlint-cli2:
         specifier: 0.13.0
         version: 0.13.0
@@ -59,13 +62,13 @@ importers:
         version: 14.2.3
       typedoc:
         specifier: 0.26.3
-        version: 0.26.4(typescript@5.5.3)
+        version: 0.26.3(typescript@5.5.3)
       typedoc-plugin-coverage:
         specifier: 3.3.0
-        version: 3.3.0(typedoc@0.26.4(typescript@5.5.3))
+        version: 3.3.0(typedoc@0.26.3(typescript@5.5.3))
       typedoc-plugin-mdn-links:
         specifier: 3.2.2
-        version: 3.2.3(typedoc@0.26.4(typescript@5.5.3))
+        version: 3.2.2(typedoc@0.26.3(typescript@5.5.3))
       vitest:
         specifier: 2.0.2
         version: 2.0.2(@types/node@20.14.9)(@vitest/ui@2.0.2)
@@ -341,8 +344,8 @@ packages:
     resolution: {integrity: sha512-EStJpq4OuY8xYfhGVXngigBJRWxftKX9ksiGDnmlY3o7B/V7KIAc9X4oiK87uPJSc/vs5L869bem5fhZa8caZw==}
     engines: {node: '>=6.9.0'}
 
-  '@babel/parser@7.24.7':
-    resolution: {integrity: sha512-9uUYRm6OqQrCqQdG1iCBwBPZgN8ciDBro2nIOFaiRz1/BCxaI7CNvQbDHvsArAC7Tw9Hda/B3U+6ui9u4HWXPw==}
+  '@babel/parser@7.25.0':
+    resolution: {integrity: sha512-CzdIU9jdP0dg7HdyB+bHvDJGagUv+qtzZt5rYCWwW6tITNqV9odjp6Qu41gkG0ca5UfdDUWrKkiAnHHdGRnOrA==}
     engines: {node: '>=6.0.0'}
     hasBin: true
 
@@ -1167,6 +1170,10 @@ packages:
     resolution: {integrity: sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==}
     engines: {node: '>=12'}
 
+  ast-types@0.16.1:
+    resolution: {integrity: sha512-6t10qk83GOG8p0vKmaCr8eiilZwO171AvbROMtvvNiwrTly62t+7XkA8RdIIVbpMhCASAsxgAzdRSwh6nw/5Dg==}
+    engines: {node: '>=4'}
+
   async@3.2.5:
     resolution: {integrity: sha512-baNZyqaaLhyLVKm/DlvdW051MSgO6b8eVfIezl9E5PqWxFgzLm/wQntEW4zOytVburDEr0JlALEpdOFwvErLsg==}
 
@@ -1618,6 +1625,11 @@ packages:
 
   esm-env@1.0.0:
     resolution: {integrity: sha512-Cf6VksWPsTuW01vU9Mk/3vRue91Zevka5SjyNf3nEpokFRuqt/KjUQoGAwq9qMmhpLTHmXzSIrFRw8zxWzmFBA==}
+
+  esprima@4.0.1:
+    resolution: {integrity: sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==}
+    engines: {node: '>=4'}
+    hasBin: true
 
   esrap@1.2.2:
     resolution: {integrity: sha512-F2pSJklxx1BlQIQgooczXCPHmcWpn6EsP5oo73LQfonG9fIlIENQ8vMmfGXeojP9MrkzUNAfyU5vdFlR9shHAw==}
@@ -2198,56 +2210,48 @@ packages:
     resolution: {integrity: sha512-o+NO+8WrRiQEE4/7nwRJhN1HWpVmJm511pBHUxPLtp0BUISzlBplORYSmTclCnJvQq2tKu/sgl3xVpkc7ZWuQQ==}
     engines: {node: '>=6'}
 
-  lefthook-darwin-arm64@1.7.1:
-    resolution: {integrity: sha512-WNM92Ix2rKmDKXzjlkVGCdzSkzzj3Z9D7yKi22KeOZ1iCXG1EtXEWmXO5M2g28FNb4cZI0r2DACNH5hz8JsfgA==}
+  lefthook-darwin-arm64@1.6.18:
+    resolution: {integrity: sha512-AkpsTeO7aLZIIy6CKQ7Chx8RltE8a9uItbwQWoeaCkIdzpV8TFjq7/Pw4F5CkoJ2315sHtB8k+VFkgipQMBw1w==}
     cpu: [arm64]
     os: [darwin]
-    hasBin: true
 
-  lefthook-darwin-x64@1.7.1:
-    resolution: {integrity: sha512-SDPEciuP+eNzuKN8kx1x0dRzFElpO65on5q0raKgTbTvSOyVd3c7sMLGluz6OSM5qqEWEdEeA8QYKpdA56uXEw==}
+  lefthook-darwin-x64@1.6.18:
+    resolution: {integrity: sha512-qwKa+PaNIYjZ2PVrRRLq+HjNjQsjEItXN21byvSD89r7EYCULsIC8aW4H6aniOP2A6X1DIZ+djpg+3hNJ/94NA==}
     cpu: [x64]
     os: [darwin]
-    hasBin: true
 
-  lefthook-freebsd-arm64@1.7.1:
-    resolution: {integrity: sha512-Ym2hhv6w7RWva3jfjtBOYck+GiaCx1JpnsOCf9tDYKFiV6ve/DoLrGQ+uI0UOqtiHN/bJzt5BrNXygfAubXaEg==}
+  lefthook-freebsd-arm64@1.6.18:
+    resolution: {integrity: sha512-UIOzQ+okwB7Ah9p8sNqomOiU6cPfmJnyW3HDPutRsdoHRD8udIap9d+ja4Kg4m/PkoYtkcLO78omANqAgA5wxQ==}
     cpu: [arm64]
     os: [freebsd]
-    hasBin: true
 
-  lefthook-freebsd-x64@1.7.1:
-    resolution: {integrity: sha512-u9WYd+LDJr1A+VQV6lTe1a0yG0Ew9Wgeb9Ym9IKr9eLblrt6JNvW1x9u0e9OFteLwnqBCCT8omBY+NARcvqVvg==}
+  lefthook-freebsd-x64@1.6.18:
+    resolution: {integrity: sha512-UQANUgyNpaAh0+2/PjPFiJ7yd6aF15yyJxKZCXyna5cQF7VU8pSHu5tiDDquNpjToXOg+6TmiIAJKyfrrwTF3w==}
     cpu: [x64]
     os: [freebsd]
-    hasBin: true
 
-  lefthook-linux-arm64@1.7.1:
-    resolution: {integrity: sha512-Sgc+vHNnAbiJ5b1yMJsFn/rQ6eVQ0KLzuL0x0KJqFZvmffFenVmqABrFHKNDzhj8//KUbHdgCgLzqQAkAbCNcg==}
+  lefthook-linux-arm64@1.6.18:
+    resolution: {integrity: sha512-4erletIa2HKUgY17/1ROvndAj6xn/9wkqO2GhBT3C0vFwIv6ycy5wpFzXOwKRZpFYv7UacN7iXhAZSK+vSOZZg==}
     cpu: [arm64]
     os: [linux]
-    hasBin: true
 
-  lefthook-linux-x64@1.7.1:
-    resolution: {integrity: sha512-UDIM6Cf0aHrfvIxeVz05M7g+omLdyTQpmB2BqkeANpd/5+1LqRMOBOdtW+y3X47NKYL++iFh2EtIhlIqVBj6Kw==}
+  lefthook-linux-x64@1.6.18:
+    resolution: {integrity: sha512-l5SRqYMYygw9RjZncEg8uh29wShYN8kiYr53sp74DkntrlCttqWhLILBUlIr3fxH5s0ZyrmqUEjtMBryMk7b/g==}
     cpu: [x64]
     os: [linux]
-    hasBin: true
 
-  lefthook-windows-arm64@1.7.1:
-    resolution: {integrity: sha512-cz3vhIdmORA25YF4ZnPjDQwi/KQd8cB89q7jHEQ9sv+bpSOTXiauMOM9jvXbnvGrmFaR1qbLRTYpKQs6oyGdsA==}
+  lefthook-windows-arm64@1.6.18:
+    resolution: {integrity: sha512-jeNBRoya3+mOEsKyT4wXf29Kng1nkJD7Uv/dqGBszoGMktGVNUFdIjWoxx6HSfhUssucs5pKRZpXSMgK/KCP+Q==}
     cpu: [arm64]
     os: [win32]
-    hasBin: true
 
-  lefthook-windows-x64@1.7.1:
-    resolution: {integrity: sha512-Fa9HEkJczbD1zu6wBKP2rR738uRei5sb76d/DzgqW09ZBTwQl+6Oiyg3kicVU1N1X8bhZ/g1h49tcHrVtjU5ww==}
+  lefthook-windows-x64@1.6.18:
+    resolution: {integrity: sha512-iEG8PbFOwMqlpAgCiqzANTxutERjwlwMx6WF6HDGEYwFJSCJsvi06TehDxaPIFbhmLLYYlbVrfSBlttWGoN0dg==}
     cpu: [x64]
     os: [win32]
-    hasBin: true
 
-  lefthook@1.7.1:
-    resolution: {integrity: sha512-WNgjrPH4bYZyAYsiK7y7roQCQFIgqdCFxVCVe7ylAFD+QvW8tMceG19mR3GS2if1fGHC/cs+Z0r6PI52b/G1eA==}
+  lefthook@1.6.18:
+    resolution: {integrity: sha512-Ftr/NkU1P1EsEyphsCqCX7lesGZA+QDXyUx4dS1RlSKB72xKtGW9VPjbGLK2kSQkONG5M+XYfbJkGA/r9NLTYQ==}
     hasBin: true
 
   lilconfig@3.1.2:
@@ -2881,6 +2885,10 @@ packages:
     resolution: {integrity: sha512-57frrGM/OCTLqLOAh0mhVA9VBMHd+9U7Zb2THMGdBUoZVOtGbJzjxsYGDJ3A9AYYCP4hn6y1TVbaOfzWtm5GFg==}
     engines: {node: '>= 12.13.0'}
 
+  recast@0.23.9:
+    resolution: {integrity: sha512-Hx/BGIbwj+Des3+xy5uAtAbdCyqK9y9wbBcDFDYanLS9JnMqf7OeF87HQwUimE87OEc72mr6tkKUKMBBL+hF9Q==}
+    engines: {node: '>= 4'}
+
   redent@3.0.0:
     resolution: {integrity: sha512-6tDA8g98We0zd0GvVeMT9arEOnTw9qM03L9cJXaCjrip1OO764RDBLBfrB4cwzNGDj5OA5ioymC9GkizgWJDUg==}
     engines: {node: '>=8'}
@@ -3461,13 +3469,13 @@ packages:
     peerDependencies:
       typedoc: 0.25.x || 0.26.x
 
-  typedoc-plugin-mdn-links@3.2.3:
-    resolution: {integrity: sha512-hz22UgFuzdtgpBXet2dxKf9d2HVixL2VcE9Ke1+X1Nu8W8jSGIB2awIA6HFVsD0vk1OLe3ehU0ibyD5sN7wh4w==}
+  typedoc-plugin-mdn-links@3.2.2:
+    resolution: {integrity: sha512-3xlxS32c29Mey5SxqgCEF1lYYceQyoILhJM0Ewh2ISW8Ql3NzhC3SGpuvft4YtzpZIdB+YR7aIMkhlDquA0M+Q==}
     peerDependencies:
       typedoc: '>= 0.23.14 || 0.24.x || 0.25.x || 0.26.x'
 
-  typedoc@0.26.4:
-    resolution: {integrity: sha512-FlW6HpvULDKgc3rK04V+nbFyXogPV88hurarDPOjuuB5HAwuAlrCMQ5NeH7Zt68a/ikOKu6Z/0hFXAeC9xPccQ==}
+  typedoc@0.26.3:
+    resolution: {integrity: sha512-6d2Sw9disvvpdk4K7VNjKr5/3hzijtfQVHRthhDqJgnhMHy1wQz4yPMJVKXElvnZhFr0nkzo+GzjXDTRV5yLpg==}
     engines: {node: '>= 18'}
     hasBin: true
     peerDependencies:
@@ -3919,11 +3927,9 @@ snapshots:
       picocolors: 1.0.1
     optional: true
 
-  '@babel/helper-string-parser@7.24.7':
-    optional: true
+  '@babel/helper-string-parser@7.24.7': {}
 
-  '@babel/helper-validator-identifier@7.24.7':
-    optional: true
+  '@babel/helper-validator-identifier@7.24.7': {}
 
   '@babel/highlight@7.24.7':
     dependencies:
@@ -3933,10 +3939,9 @@ snapshots:
       picocolors: 1.0.1
     optional: true
 
-  '@babel/parser@7.24.7':
+  '@babel/parser@7.25.0':
     dependencies:
       '@babel/types': 7.24.7
-    optional: true
 
   '@babel/runtime@7.24.7':
     dependencies:
@@ -3948,7 +3953,6 @@ snapshots:
       '@babel/helper-string-parser': 7.24.7
       '@babel/helper-validator-identifier': 7.24.7
       to-fast-properties: 2.0.0
-    optional: true
 
   '@bcoe/v8-coverage@0.2.3':
     optional: true
@@ -4827,6 +4831,10 @@ snapshots:
   assertion-error@2.0.1:
     optional: true
 
+  ast-types@0.16.1:
+    dependencies:
+      tslib: 2.6.3
+
   async@3.2.5:
     optional: true
 
@@ -5480,6 +5488,8 @@ snapshots:
     optional: true
 
   esm-env@1.0.0: {}
+
+  esprima@4.0.1: {}
 
   esrap@1.2.2:
     dependencies:
@@ -6206,40 +6216,40 @@ snapshots:
 
   kleur@4.1.5: {}
 
-  lefthook-darwin-arm64@1.7.1:
+  lefthook-darwin-arm64@1.6.18:
     optional: true
 
-  lefthook-darwin-x64@1.7.1:
+  lefthook-darwin-x64@1.6.18:
     optional: true
 
-  lefthook-freebsd-arm64@1.7.1:
+  lefthook-freebsd-arm64@1.6.18:
     optional: true
 
-  lefthook-freebsd-x64@1.7.1:
+  lefthook-freebsd-x64@1.6.18:
     optional: true
 
-  lefthook-linux-arm64@1.7.1:
+  lefthook-linux-arm64@1.6.18:
     optional: true
 
-  lefthook-linux-x64@1.7.1:
+  lefthook-linux-x64@1.6.18:
     optional: true
 
-  lefthook-windows-arm64@1.7.1:
+  lefthook-windows-arm64@1.6.18:
     optional: true
 
-  lefthook-windows-x64@1.7.1:
+  lefthook-windows-x64@1.6.18:
     optional: true
 
-  lefthook@1.7.1:
+  lefthook@1.6.18:
     optionalDependencies:
-      lefthook-darwin-arm64: 1.7.1
-      lefthook-darwin-x64: 1.7.1
-      lefthook-freebsd-arm64: 1.7.1
-      lefthook-freebsd-x64: 1.7.1
-      lefthook-linux-arm64: 1.7.1
-      lefthook-linux-x64: 1.7.1
-      lefthook-windows-arm64: 1.7.1
-      lefthook-windows-x64: 1.7.1
+      lefthook-darwin-arm64: 1.6.18
+      lefthook-darwin-x64: 1.6.18
+      lefthook-freebsd-arm64: 1.6.18
+      lefthook-freebsd-x64: 1.6.18
+      lefthook-linux-arm64: 1.6.18
+      lefthook-linux-x64: 1.6.18
+      lefthook-windows-arm64: 1.6.18
+      lefthook-windows-x64: 1.6.18
     optional: true
 
   lilconfig@3.1.2: {}
@@ -6327,7 +6337,7 @@ snapshots:
 
   magicast@0.3.4:
     dependencies:
-      '@babel/parser': 7.24.7
+      '@babel/parser': 7.25.0
       '@babel/types': 7.24.7
       source-map-js: 1.2.0
     optional: true
@@ -6945,6 +6955,14 @@ snapshots:
 
   real-require@0.2.0: {}
 
+  recast@0.23.9:
+    dependencies:
+      ast-types: 0.16.1
+      esprima: 4.0.1
+      source-map: 0.6.1
+      tiny-invariant: 1.3.3
+      tslib: 2.6.3
+
   redent@3.0.0:
     dependencies:
       indent-string: 4.0.0
@@ -7522,8 +7540,7 @@ snapshots:
       os-tmpdir: 1.0.2
     optional: true
 
-  to-fast-properties@2.0.0:
-    optional: true
+  to-fast-properties@2.0.0: {}
 
   to-regex-range@5.0.1:
     dependencies:
@@ -7591,8 +7608,7 @@ snapshots:
   tslib@2.1.0:
     optional: true
 
-  tslib@2.6.3:
-    optional: true
+  tslib@2.6.3: {}
 
   tsup@8.1.0(@microsoft/api-extractor@7.47.0(@types/node@20.14.9))(postcss@8.4.39)(ts-node@10.9.2(@types/node@20.14.9)(typescript@5.5.3))(typescript@5.5.3):
     dependencies:
@@ -7673,17 +7689,17 @@ snapshots:
       possible-typed-array-names: 1.0.0
     optional: true
 
-  typedoc-plugin-coverage@3.3.0(typedoc@0.26.4(typescript@5.5.3)):
+  typedoc-plugin-coverage@3.3.0(typedoc@0.26.3(typescript@5.5.3)):
     dependencies:
-      typedoc: 0.26.4(typescript@5.5.3)
+      typedoc: 0.26.3(typescript@5.5.3)
     optional: true
 
-  typedoc-plugin-mdn-links@3.2.3(typedoc@0.26.4(typescript@5.5.3)):
+  typedoc-plugin-mdn-links@3.2.2(typedoc@0.26.3(typescript@5.5.3)):
     dependencies:
-      typedoc: 0.26.4(typescript@5.5.3)
+      typedoc: 0.26.3(typescript@5.5.3)
     optional: true
 
-  typedoc@0.26.4(typescript@5.5.3):
+  typedoc@0.26.3(typescript@5.5.3):
     dependencies:
       lunr: 2.3.9
       markdown-it: 14.1.0

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4,13 +4,18 @@ settings:
   autoInstallPeers: true
   excludeLinksFromLockfile: false
 
+patchedDependencies:
+  recast@0.23.9:
+    hash: mz3n7u6bodxd4squxjzhzvgf6y
+    path: patches/recast@0.23.9.patch
+
 importers:
 
   .:
     dependencies:
       recast:
         specifier: ^0.23.9
-        version: 0.23.9
+        version: 0.23.9(patch_hash=mz3n7u6bodxd4squxjzhzvgf6y)
       zimmerframe:
         specifier: 1.1.2
         version: 1.1.2
@@ -6956,7 +6961,7 @@ snapshots:
 
   real-require@0.2.0: {}
 
-  recast@0.23.9:
+  recast@0.23.9(patch_hash=mz3n7u6bodxd4squxjzhzvgf6y):
     dependencies:
       ast-types: 0.16.1
       esprima: 4.0.1

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,9 +8,6 @@ importers:
 
   .:
     dependencies:
-      '@babel/parser':
-        specifier: ^7.25.0
-        version: 7.25.0
       recast:
         specifier: ^0.23.9
         version: 0.23.9
@@ -3927,9 +3924,11 @@ snapshots:
       picocolors: 1.0.1
     optional: true
 
-  '@babel/helper-string-parser@7.24.7': {}
+  '@babel/helper-string-parser@7.24.7':
+    optional: true
 
-  '@babel/helper-validator-identifier@7.24.7': {}
+  '@babel/helper-validator-identifier@7.24.7':
+    optional: true
 
   '@babel/highlight@7.24.7':
     dependencies:
@@ -3942,6 +3941,7 @@ snapshots:
   '@babel/parser@7.25.0':
     dependencies:
       '@babel/types': 7.24.7
+    optional: true
 
   '@babel/runtime@7.24.7':
     dependencies:
@@ -3953,6 +3953,7 @@ snapshots:
       '@babel/helper-string-parser': 7.24.7
       '@babel/helper-validator-identifier': 7.24.7
       to-fast-properties: 2.0.0
+    optional: true
 
   '@bcoe/v8-coverage@0.2.3':
     optional: true
@@ -7540,7 +7541,8 @@ snapshots:
       os-tmpdir: 1.0.2
     optional: true
 
-  to-fast-properties@2.0.0: {}
+  to-fast-properties@2.0.0:
+    optional: true
 
   to-regex-range@5.0.1:
     dependencies:

--- a/src/mod.js
+++ b/src/mod.js
@@ -6,7 +6,7 @@
  * @import { Node } from "./nodes.js";
  */
 
-import { print as print_es } from "recast";
+import { print as recastPrint } from "recast";
 import { walk } from "zimmerframe";
 
 import { is_attribute_like_node, is_element_like_node, is_svelte_node } from "./nodes.js";
@@ -70,6 +70,10 @@ export function print(node, options = {}) {
 	}
 
 	return print_es(node).code;
+}
+
+function print_es(node) {
+	return recastPrint(node, { quote: "single" })
 }
 
 class Printer {

--- a/src/mod.js
+++ b/src/mod.js
@@ -6,7 +6,7 @@
  * @import { Node } from "./nodes.js";
  */
 
-import { print as print_es } from "esrap";
+import { print as print_es } from "recast";
 import { walk } from "zimmerframe";
 
 import { is_attribute_like_node, is_element_like_node, is_svelte_node } from "./nodes.js";

--- a/src/mod.js
+++ b/src/mod.js
@@ -73,7 +73,7 @@ export function print(node, options = {}) {
 }
 
 function print_es(node) {
-	return recastPrint(node, { quote: "single" })
+	return recastPrint(node, { quote: "single", useTabs: true })
 }
 
 class Printer {

--- a/tests/nodes/root.test.ts
+++ b/tests/nodes/root.test.ts
@@ -6,7 +6,9 @@ import { parse_and_extract_svelte_node } from "#tests/mod";
 import { print } from "svelte-ast-print";
 
 describe("Root", () => {
-	it("it prints correctly Svelte code without TypeScript syntax", ({ expect }) => {
+	it("it prints correctly Svelte code without TypeScript syntax", ({
+		expect,
+	}) => {
 		const code = `
 			<script context="module">
 				export const FOO = "BAR";
@@ -81,22 +83,22 @@ describe("Root", () => {
 		expect(print(node)).toMatchInlineSnapshot(
 			`
 			"<script context="module">
-				export const FOO = "BAR";
+				export const FOO = 'BAR';
 			</script>
 
 			<script>
 				let todos = [
-					{ done: false, text: 'finish Svelte tutorial' },
-					{ done: false, text: 'build an app' },
-					{ done: false, text: 'world domination' }
+				    { done: false, text: 'finish Svelte tutorial' },
+				    { done: false, text: 'build an app' },
+				    { done: false, text: 'world domination' }
 				];
 
 				function add() {
-					todos = todos.concat({ done: false, text: '' });
+				    todos = todos.concat({ done: false, text: '' });
 				}
 
 				function clear() {
-					todos = todos.filter((t) => !t.done);
+				    todos = todos.filter(t => !t.done);
 				}
 
 				$: remaining = todos.filter((t) => !t.done).length;
@@ -142,11 +144,13 @@ describe("Root", () => {
 					border: none;
 				}
 			</style>"
-		`,
+		`
 		);
 	});
 
-	it.fails("it prints correctly Svelte code with TypeScript syntax", ({ expect }) => {
+	it("it prints correctly Svelte code with TypeScript syntax", ({
+		expect,
+	}) => {
 		const code = `
 			<script context="module" lang="ts">
 				import {
@@ -212,7 +216,6 @@ describe("Root", () => {
 				import { defineMeta, setTemplate, type Args, type StoryContext } from '@storybook/addon-svelte-csf';
 				import { fn } from '@storybook/test';
 				import Button from './components/Button.svelte';
-
 				const onclickFn = fn().mockName('onclick');
 
 				/**
@@ -237,6 +240,7 @@ describe("Root", () => {
 			<script lang="ts">
 				setTemplate(template);
 			</script>
+
 			{#snippet template({ children, ...args }: Args<typeof Story>, context: StoryContext<typeof Story>)}
 				<Button {...args}>{children}</Button>
 			{/snippet}
@@ -249,7 +253,7 @@ describe("Root", () => {
 			<Story name="Long content">
 				<Button onclick={onclickFn}>The very long content</Button>
 			</Story>"
-		`,
+		`
 		);
 	});
 
@@ -274,10 +278,8 @@ describe("Root", () => {
 		const node = parse_and_extract_svelte_node<Root>(code, "Root");
 		expect(print(node)).toMatchInlineSnapshot(`
 			"<script context="module">
-				import { defineMeta } from "@storybook/addon-svelte-csf";
-
-				/** This is a description for the **Button** component stories. */
-				const { Story } = defineMeta({ title: "Atoms/Button", component: Button });
+				import { defineMeta } from '@storybook/addon-svelte-csf';
+				const { Story } = defineMeta({ title: 'Atoms/Button', component: Button });
 			</script>
 
 			<!-- This is a description for the **Button** component stories. -->

--- a/tests/nodes/script.test.ts
+++ b/tests/nodes/script.test.ts
@@ -19,7 +19,7 @@ describe("Script", () => {
 		const node = parse_and_extract_svelte_node<Root>(code, "Root");
 		expect(print(node)).toMatchInlineSnapshot(`
 			"<script context="module" lang="ts">
-				export const BUTTON_DEFAULT_VARIANT = "primary";
+				export const BUTTON_DEFAULT_VARIANT = 'primary';
 			</script>
 
 			<script lang="ts">
@@ -28,7 +28,9 @@ describe("Script", () => {
 		`);
 	});
 
-	it("prints correctly advanced content without TypeScript syntax", ({ expect }) => {
+	it("prints correctly advanced content without TypeScript syntax", ({
+		expect,
+	}) => {
 		const code = `
 			<script>
 				import Eliza from 'elizabot';
@@ -84,7 +86,6 @@ describe("Script", () => {
 			"<script>
 				import Eliza from 'elizabot';
 				import { beforeUpdate, afterUpdate } from 'svelte';
-
 				let div;
 
 				beforeUpdate(() => {}); // determine whether we should auto-scroll
@@ -92,25 +93,20 @@ describe("Script", () => {
 				afterUpdate(() => {}); // ...the DOM is now in sync with the data
 
 				const eliza = new Eliza();
-				const pause = (ms) => new Promise((fulfil) => setTimeout(fulfil, ms));
+				const pause = ms => new Promise(fulfil => setTimeout(fulfil, ms));
 				const typing = { author: 'eliza', text: '...' };
 				let comments = [];
 
 				async function handleKeydown(event) {
-					if (event.key === 'Enter' && event.target.value) {
-						const comment = { author: 'user', text: event.target.value };
-
-						const reply = {
-							author: 'eliza',
-							text: eliza.transform(comment.text)
-						};
-
+				    if (event.key === 'Enter' && event.target.value) {
+					    const comment = { author: 'user', text: event.target.value };
+						const reply = { author: 'eliza', text: eliza.transform(comment.text) };
 						event.target.value = '';
 						comments = [...comments, comment];
 						await pause(200 * (1 + Math.random()));
 						comments = [...comments, typing];
 						await pause(500 * (1 + Math.random()));
-						comments = [...comments, reply].filter((comment) => comment !== typing);
+						comments = [...comments, reply].filter(comment => comment !== typing);
 					}
 				}
 			</script>"
@@ -133,7 +129,7 @@ describe("Script", () => {
 				let name: string = 'world';
 
 				function greet(name: string) {
-					alert(\`Hello, \${name}!\`);
+				    alert(\`Hello, \${name}!\`);
 				}
 			</script>"
 		`);

--- a/tests/nodes/script.test.ts
+++ b/tests/nodes/script.test.ts
@@ -117,7 +117,7 @@ describe("Script", () => {
 		`);
 	});
 
-	it.fails("prints content with TypeScript syntax", ({ expect }) => {
+	it("prints content with TypeScript syntax", ({ expect }) => {
 		const code = `
 			<script lang="ts">
 				let name: string = 'world';


### PR DESCRIPTION
Closes #86 
Relates https://github.com/svelte-add/svelte-add/issues/507
Relates https://github.com/svelte-add/svelte-add/issues/193

I wanted to see if we can get any closer to supporting typescript, while using the tooling we are currently using in `svelte-add`. And this comes surprisingly close, with "only" 12 tests failing.

Of course there are a few things I didn't bother about right now:
* There are a few formatting differences between `esrap` and `recast`, especially regarding quotes and lines breaks (11 failed tests)
* Exceptions (1 test)

Otherwise the typescript test should be working as expected:
![image](https://github.com/user-attachments/assets/6319d693-f228-42a2-87e3-c7d43b001742)


This is by no means a full implementation, and we should probably add more tests to see if this works as expected, even inside html templates potentially. This is a minimal implementation, that's why I did not bother renaming `print_es`

On other notes:
* Linting script seems to be off, although main seems to be passing (produces to many errors locally to display them all in the console)
* Pipeline is reporting three snapshot failures but is still passing (https://github.com/xeho91/svelte-ast-print/actions/runs/9885196416/job/27302793808)
* That's maybe on me: vscode tries to format every file completely differently as it's in the repository. I had to save my stuff "without formatting" to produce this minimal diff.