### PR TITLE
docs: Add important note about `modern: true` with Svelte `parse`

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,7 +106,8 @@ This package depends on:
    ```
 
 > [!IMPORTANT]
-> When using [`parse`] from `svelte`, please remember about passing `modern: true` to options _(second argument)_. This option is only available starting `svelte@5`\
+> When using [`parse`] from `svelte`, please remember about passing `modern: true` to options _(second argument)_.
+> This option is only available starting `svelte@5`\
 > Example:
 >
 > ```js

--- a/README.md
+++ b/README.md
@@ -105,6 +105,10 @@ This package depends on:
    fs.writeFileSync("src/App.svelte", output, { encoding: " utf-8" });
    ```
 
+    > [!IMPORTANT]
+    > When using [`parse`] from `svelte`, please remember about passing `modern: true` to options _(second argument)_.\
+    > You can omit it from Svelte `v6` - [source](https://github.com/sveltejs/svelte/blob/5a05f6371a994286626a44168cb2c02f8a2ad567/packages/svelte/src/compiler/index.js#L99-L100).
+
 ## Contributing
 
 Take a look at [contributing guide](./.github/CONTRIBUTING.md).
@@ -143,6 +147,7 @@ Mateusz "[xeho91](https://github.com/xeho91)" Kadlubowski
 This project is licensed under the [MIT License](./LICENSE.md).
 
 <!-- links -->
+
 [`esrap`]: https://github.com/rich-harris/esrap
 [`zimmerframe`]: https://github.com/rich-harris/zimmerframe
 [ESTree]: https://github.com/estree/estree

--- a/README.md
+++ b/README.md
@@ -106,7 +106,7 @@ This package depends on:
    ```
 
 > [!IMPORTANT]
-> When using [`parse`] from `svelte`, please remember about passing `modern: true` to options _(second argument)_.\
+> When using [`parse`] from `svelte`, please remember about passing `modern: true` to options _(second argument)_. This option is only available starting `svelte@5`\
 > Example:
 >
 > ```js

--- a/README.md
+++ b/README.md
@@ -105,9 +105,18 @@ This package depends on:
    fs.writeFileSync("src/App.svelte", output, { encoding: " utf-8" });
    ```
 
-    > [!IMPORTANT]
-    > When using [`parse`] from `svelte`, please remember about passing `modern: true` to options _(second argument)_.\
-    > You can omit it from Svelte `v6` - [source](https://github.com/sveltejs/svelte/blob/5a05f6371a994286626a44168cb2c02f8a2ad567/packages/svelte/src/compiler/index.js#L99-L100).
+> [!IMPORTANT]
+> When using [`parse`] from `svelte`, please remember about passing `modern: true` to options _(second argument)_.\
+> Example:
+>
+> ```js
+> import { parse } from "svelte/compiler";
+>
+> parse(code, { modern: true });
+> //          👆 Don't forget about this
+> ```
+>
+> You can omit it from Svelte `v6` - [source](https://github.com/sveltejs/svelte/blob/5a05f6371a994286626a44168cb2c02f8a2ad567/packages/svelte/src/compiler/index.js#L99-L100).
 
 ## Contributing
 


### PR DESCRIPTION
Resolves #89
