### PR TITLE
fix: Usage & import of AST types from `svelte/compiler`

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,11 +4,7 @@
 	"version": "0.2.4",
 	"type": "module",
 	"description": "Print Svelte AST nodes as a string. Aka parse in reverse.",
-	"keywords": [
-		"svelte",
-		"ast",
-		"print"
-	],
+	"keywords": ["svelte", "ast", "print"],
 	"license": "MIT",
 	"author": {
 		"name": "Mateusz Kadlubowski",
@@ -38,10 +34,7 @@
 	"engines": {
 		"node": ">=20"
 	},
-	"files": [
-		"src/",
-		"types/"
-	],
+	"files": ["src/", "types/"],
 	"imports": {
 		"#tests/*": {
 			"types": "./tests/*.ts",
@@ -104,13 +97,13 @@
 		"@types/node": "22.5.0",
 		"dedent": "1.5.3",
 		"dts-buddy": "0.5.3",
-		"svelte": "5.0.0-next.239",
+		"svelte": "5.0.0-next.243",
 		"tsup": "8.2.4",
 		"type-fest": "4.25.0",
 		"typescript": "5.5.4"
 	},
 	"peerDependencies": {
-		"svelte": "^5.0.0-next.239 || ^5.0.0"
+		"svelte": "^5.0.0-next.243 || ^5.0.0"
 	},
 	"optionalDependencies": {
 		"@auto-it/all-contributors": "11.2.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -89,8 +89,8 @@ importers:
         specifier: 0.5.3
         version: 0.5.3(typescript@5.5.4)
       svelte:
-        specifier: 5.0.0-next.239
-        version: 5.0.0-next.239
+        specifier: 5.0.0-next.243
+        version: 5.0.0-next.243
       tsup:
         specifier: 8.2.4
         version: 8.2.4(@microsoft/api-extractor@7.47.7(@types/node@22.5.0))(postcss@8.4.41)(typescript@5.5.4)(yaml@2.5.0)
@@ -3439,8 +3439,8 @@ packages:
     resolution: {integrity: sha512-e+V1dSZLCCu0Ln7RKwSl/zP9ZZFbDGW7ABfGQYU/+6sWponizQocmyHyKHzctor0ruGgJKOF7QQB+M6lE2+UrA==}
     engines: {node: '>=18'}
 
-  svelte@5.0.0-next.239:
-    resolution: {integrity: sha512-zJJlysnVl4zShMwrs6iIeQPm0bHi7eT0JR0W0U/u2naDb00azue1K5d14cbCoIh+/HA3F+tuawwSFISZsnadww==}
+  svelte@5.0.0-next.243:
+    resolution: {integrity: sha512-+oXjRInUyBfZXAEY8hmpf3F0eghAVCoWasotz1iOp2G5CyH4KR7jPxWOgjbgsgpL4zlMiN32MEYU1+I+QsC+nQ==}
     engines: {node: '>=18'}
 
   table-layout@1.0.2:
@@ -7769,7 +7769,7 @@ snapshots:
       magic-string: 0.30.10
       zimmerframe: 1.1.2
 
-  svelte@5.0.0-next.239:
+  svelte@5.0.0-next.243:
     dependencies:
       '@ampproject/remapping': 2.3.0
       '@jridgewell/sourcemap-codec': 1.5.0

--- a/src/nodes.js
+++ b/src/nodes.js
@@ -1,10 +1,21 @@
 /**
  * @import * as _reset from "@total-typescript/ts-reset";
  * @import { Node as ESTreeNode } from "estree";
- * @import * as Svelte from "svelte/compiler";
+ * @import { AST, Css, parse } from "svelte/compiler";
  */
 
-/** @typedef {Svelte.Attribute | Svelte.SpreadAttribute | Svelte.Directive} AttributeLike */
+/**
+ * TODO: Svelte could expose this type to public too: https://github.com/sveltejs/svelte/blob/2b362ddc63e930726b67a1010d2829a3a4f6bb85/packages/svelte/src/compiler/types/template.d.ts#L514
+ * FIXME: Include `Css.Node` when exposed to public
+ * @typedef {ESTreeNode | TemplateNode | AST.Fragment} SvelteNode
+ */
+
+/**
+ * TODO: Svelte could expose this type to public too: https://github.com/sveltejs/svelte/blob/2b362ddc63e930726b67a1010d2829a3a4f6bb85/packages/svelte/src/compiler/types/template.d.ts#L476
+ * @typedef {AST.AnimateDirective | AST.BindDirective | AST.ClassDirective | AST.LetDirective | AST.OnDirective | AST.SpreadAttribute | AST.StyleDirective | AST.TransitionDirective | AST.UseDirective} Directive
+ */
+
+/** @typedef {AST.Attribute | AST.SpreadAttribute | Directive} AttributeLike */
 const ATTRIBUTE_LIKE_NODE_NAMES = new Set(
 	/** @type {const} */ ([
 		"AnimateDirective",
@@ -19,19 +30,25 @@ const ATTRIBUTE_LIKE_NODE_NAMES = new Set(
 		"UseDirective",
 	]),
 );
+
 /**
  * Type check guard to see if provided AST node is {@link AttributeLike}.
  *
- * - Standard attribute _({@link Svelte.Attribute})_ - {@link https://developer.mozilla.org/en-US/docs/Glossary/Attribute}
- * - Spread attribute _({@link Svelte.SpreadAttribute})_ - {@link https://svelte.dev/docs/basic-markup#attributes-and-props}
- * - Directive _({@link Svelte.Directive})_ - can be for:
+ * - Standard attribute _({@link AST.Attribute})_ - {@link https://developer.mozilla.org/en-US/docs/Glossary/Attribute}
+ * - Spread attribute _({@link AST.SpreadAttribute})_ - {@link https://svelte.dev/docs/basic-markup#attributes-and-props}
+ * - Directive _({@link AST.Directive})_ - can be for:
  *   - component - {@link https://svelte.dev/docs/component-directives}
  *   - element - {@link https://svelte.dev/docs/element-directives}
  *
- * @param {Svelte.SvelteNode} node - Supported AST node to narrow down its inferred type
+ * @param {SvelteNode} node - Supported AST node to narrow down its inferred type
  * @returns {node is AttributeLike}
  */
 export const is_attribute_like_node = (node) => ATTRIBUTE_LIKE_NODE_NAMES.has(node.type);
+
+/**
+ * TODO: Svelte could expose this type to public too: https://github.com/sveltejs/svelte/blob/2b362ddc63e930726b67a1010d2829a3a4f6bb85/packages/svelte/src/compiler/types/template.d.ts#L486
+ * @typedef {AST.EachBlock | AST.IfBlock | AST.AwaitBlock | AST.KeyBlock | AST.SnippetBlock} Block
+ */
 
 const BLOCK_NODE_NAMES = new Set(
 	/** @type {const} */ ([
@@ -44,16 +61,17 @@ const BLOCK_NODE_NAMES = new Set(
 		"SnippetBlock",
 	]),
 );
+
 /**
- * Type check guard to see if provided AST node is a logic block {@link Svelte.Block}.
+ * Type check guard to see if provided AST node is a logic block {@link Block}.
  *
  * @see {@link https://svelte.dev/docs/logic-blocks}
  *
- * NOTE: Svelte v5 includes a new block {@link Svelte.SnippetBlock}
+ * NOTE: Svelte v5 includes a new block {@link AST.SnippetBlock}
  * @see {@link https://svelte-5-preview.vercel.app/docs/snippets}
  *
- * @param {Svelte.SvelteNode} node - Supported AST node to narrow down its inferred type
- * @returns {node is Svelte.Block}
+ * @param {SvelteNode} node - Supported AST node to narrow down its inferred type
+ * @returns {node is Block}
  */
 export const is_block_node = (node) => BLOCK_NODE_NAMES.has(node.type);
 
@@ -80,14 +98,19 @@ const CSS_AST_NODE_NAMES = new Set(
 	]),
 );
 /**
- * Type check guard to see if provided AST node is a CSS based {@link Svelte.Css.Node}.
+ * FIXME: `Css` is not exported
+ * Type check guard to see if provided AST node is a CSS based {@link Css.Node}.
  *
  * WARN: Good to know: they're not same _(complaint)_ with `css-tree`!
  *
- * @param {Svelte.SvelteNode} node - Supported AST node to narrow down its inferred type
- * @returns {node is Svelte.Css.Node}
+ * @param {SvelteNode} node - Supported AST node to narrow down its inferred type
+ * @returns {node is AST.Css.Node}
  */
 export const is_css_node = (node) => CSS_AST_NODE_NAMES.has(node.type);
+
+/**
+ * TODO: Svelte could expose this type to public too: https://github.com/sveltejs/svelte/blob/2b362ddc63e930726b67a1010d2829a3a4f6bb85/packages/svelte/src/compiler/types/template.d.ts#L488
+ * @typedef {AST.Component | AST.TitleElement | AST.SlotElement | AST.RegularElement | AST.SvelteBody | AST.SvelteComponent | AST.SvelteDocument | AST.SvelteElement | AST.SvelteFragment | AST.SvelteHead | AST.SvelteOptionsRaw | AST.SvelteSelf | AST.SvelteWindow} ElementLike */
 
 const ELEMENT_LIKE_NODE_NAMES = new Set(
 	/** @type {const} */ ([
@@ -107,20 +130,21 @@ const ELEMENT_LIKE_NODE_NAMES = new Set(
 	]),
 );
 /**
- * Type check guard to see if provided AST node is "element-like" {@link Svelte.ElementLike}.
+ * Type check guard to see if provided AST node is "element-like" {@link ElementLike}.
  *
  * Those are:
  *
- * - standard Svelte-based component - {@link Svelte.Component}
+ * - standard Svelte-based component - {@link AST.Component}
  * - regular element _(HTML based)_ - {@link https://developer.mozilla.org/en-US/docs/Web/HTML/Element}
  * - special Svelte elements - {@link https://svelte.dev/docs/special-elements}
  *
- * @param {Svelte.SvelteNode} node - Supported AST node to narrow down its inferred type
- * @returns {node is Svelte.ElementLike}
+ * @param {SvelteNode} node - Supported AST node to narrow down its inferred type
+ * @returns {node is ElementLike}
  */
 export const is_element_like_node = (node) => ELEMENT_LIKE_NODE_NAMES.has(node.type);
 
-/** @typedef {Svelte.Comment | Svelte.Text} HtmlNode */
+/** @typedef {AST.Comment | AST.Text} HtmlNode */
+
 const HTML_NODE_NAMES = new Set(
 	/** @type {const} */ ([
 		//
@@ -133,10 +157,10 @@ const HTML_NODE_NAMES = new Set(
  *
  * Those are:
  *
- * - text that is included between HTML tags - {@link Svelte.Text}
- * - HTML comment - {@link Svelte.Comment}
+ * - text that is included between HTML tags - {@link AST.Text}
+ * - HTML comment - {@link AST.Comment}
  *
- * @param {Svelte.SvelteNode} node
+ * @param {SvelteNode} node
  * @returns {node is HtmlNode}
  */
 export const is_html_node = (node) => HTML_NODE_NAMES.has(node.type);
@@ -151,32 +175,43 @@ const TAG_NODE_NAMES = new Set(
 		"RenderTag",
 	]),
 );
+
 /**
- * Type check guard to see if provided AST node is "tag-like" {@link Svelte.Tag}.
+ * TODO: Svelte could expose this type to public too: https://github.com/sveltejs/svelte/blob/2b362ddc63e930726b67a1010d2829a3a4f6bb85/packages/svelte/src/compiler/types/template.d.ts#L474
+ * @typedef {AST.ExpressionTag | AST.HtmlTag | AST.ConstTag | AST.DebugTag | AST.RenderTag} Tag
+ */
+
+/**
+ * Type check guard to see if provided AST node is "tag-like" {@link Tag}.
  *
  * @see {@link https://svelte.dev/docs/special-tags}
  *
  * Not included in the documentation:
  *
- * - expression tag _({@link Svelte.ExpressionTag})_
- * - render tag _({@link Svelte.RenderTag})_ - part of Svelte v5
+ * - expression tag _({@link AST.ExpressionTag})_
+ * - render tag _({@link AST.RenderTag})_ - part of Svelte v5
  *
- * @param {Svelte.SvelteNode} node - Supported AST node to narrow down its inferred type
- * @returns {node is Svelte.Tag}
+ * @param {SvelteNode} node - Supported AST node to narrow down its inferred type
+ * @returns {node is Tag}
  */
 export const is_tag_node = (node) => TAG_NODE_NAMES.has(node.type);
 
 /**
- * Type check guard to see if provided AST node is part of node used for templating {@link Svelte.TemplateNode}.
+ * TODO: Svelte could expose this type to public too: https://github.com/sveltejs/svelte/blob/2b362ddc63e930726b67a1010d2829a3a4f6bb85/packages/svelte/src/compiler/types/template.d.ts#L503
+ * @typedef {AST.Root | AST.Text | Tag | ElementLike | AST.Attribute | AST.SpreadAttribute | Directive | AST.Comment | Block} TemplateNode
+ */
+
+/**
+ * Type check guard to see if provided AST node is part of node used for templating {@link TemplateNode}.
  *
  * Those are:
  *
- * - root - what you obtain from the results of from using {@link Svelte.parse}
- * - text that is included between HTML tags - {@link Svelte.Text}
- * - HTML comment - {@link Svelte.Comment}
+ * - root - what you obtain from the results of from using {@link parse}
+ * - text that is included between HTML tags - {@link AST.Text}
+ * - HTML comment - {@link AST.Comment}
  *
- * @param {Svelte.SvelteNode} node - Supported AST node to narrow down its inferred type
- * @returns {node is Svelte.TemplateNode}
+ * @param {SvelteNode} node - Supported AST node to narrow down its inferred type
+ * @returns {node is TemplateNode}
  */
 export const is_template_node = (node) =>
 	node.type === "Root" ||
@@ -188,12 +223,12 @@ export const is_template_node = (node) =>
 	is_html_node(node) ||
 	is_tag_node(node);
 
-// TODO: Ask Svelte maintainers if `Script` and `SvelteOptions` were omittted from `SvelteNode` intentionally - possibly forgotten to include
+// TODO: Ask Svelte maintainers if `Script` and `SvelteOptions` were omittted from `SvelteNode` intentionally
 /**
- * Not all of the nodes are bundled together with {@link Svelte.SvelteNode}.
+ * Not all of the nodes are bundled together with {@link AST.BaseNode}.
  * This type wraps them together as supported ones for printing.
  *
- * @typedef {Svelte.Script | Svelte.SvelteNode | Svelte.SvelteOptionsRaw} SupportedSvelteNode
+ * @typedef {AST.Script | AST.BaseNode | AST.SvelteOptionsRaw | SvelteNode} SupportedSvelteNode
  */
 
 /**

--- a/tests/nodes/attribute-like.test.ts
+++ b/tests/nodes/attribute-like.test.ts
@@ -51,7 +51,7 @@ describe("Attribute", () => {
 			<Select values={[1, 2, 3]} />
 		`;
 		const node = parse_and_extract_svelte_node<Attribute>(code, "Attribute");
-		expect(print(node)).toMatchInlineSnapshot(`"id={\`button-\${id}\`}"`);
+		expect(print(node)).toMatchInlineSnapshot(`"values={[1, 2, 3]}"`);
 	});
 
 	it("correctly prints expression tag with object expression", ({ expect }) => {
@@ -59,7 +59,7 @@ describe("Attribute", () => {
 			<Container values={{ min: 1000, max: 1200, display: "grid" }} />
 		`;
 		const node = parse_and_extract_svelte_node<Attribute>(code, "Attribute");
-		expect(print(node)).toMatchInlineSnapshot(`"id={\`button-\${id}\`}"`);
+		expect(print(node)).toMatchInlineSnapshot(`"values={{ min: 1000, max: 1200, display: "grid" }}"`);
 	});
 });
 

--- a/tests/nodes/script.test.ts
+++ b/tests/nodes/script.test.ts
@@ -92,10 +92,12 @@ describe("Script", () => {
 				beforeUpdate(() => {
 					// determine whether we should auto-scroll
 					// once the DOM is updated...
+					console.log(div);
 				});
 
 				afterUpdate(() => {
 					// ...the DOM is now in sync with the data
+					console.log(div);
 				});
 
 				const eliza = new Eliza();


### PR DESCRIPTION

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>0.2.5--canary.96.10713131136.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install svelte-ast-print@0.2.5--canary.96.10713131136.0
  # or 
  yarn add svelte-ast-print@0.2.5--canary.96.10713131136.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
