### PR TITLE
fix(dependencies): Remove `lefthook` from `optionalDependencies`

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -21,6 +21,7 @@ You must have those tools installed.
 | ❗required | [Node.js]  | LTS                                                  |
 | ❗required | [pnpm]     | Use `corepack enable` to automatically setup version |
 | _optional_ | [typos]    | latest                                               |
+| _optional_ | [lefthook] | latest                                               |
 
 ---
 
@@ -30,30 +31,31 @@ You must have those tools installed.
 
 1. Setup the used Node.js package manager with [corepack]:
 
-   ```sh
-   corepack enable
-   ```
+    ```sh
+    corepack enable
+    ```
 
 1. Install project dependencies with pnpm:
 
-   ```sh
-   pnpm install
-   ```
+    ```sh
+    pnpm install
+    ```
 
 1. _(optional)_ Install Git hooks with:
 
-   ```sh
-   pnpm lefthook install
-   ```
+    ```sh
+    pnpm lefthook -g install
+    ```
 
-   > [!NOTE]
-   > This can save your time and project's CI & CD usage _(even if it's free)_
+    > [!NOTE]
+    > This can save your time and project's CI & CD usage _(even if it's free)_
 
 1. Take a look at the `"scripts"` in [`./package.json`](../package.json#scripts) to see if you can find what you need.
 
-   For the the usage convienience those scripts concurrently run related tasks:
-   - `pnpm build`
-   - `pnpm dev` <- this is for the development
+    For the the usage convienience those scripts concurrently run related tasks:
+
+    - `pnpm build`
+    - `pnpm dev` <- this is for the development
 
 1. If you intend to push changes...
    You can either rely on the optional step 4 to automatically do lint checks _(related to the changed files)_

--- a/package.json
+++ b/package.json
@@ -4,11 +4,7 @@
 	"version": "0.2.5",
 	"type": "module",
 	"description": "Print Svelte AST nodes as a string. Aka parse in reverse.",
-	"keywords": [
-		"svelte",
-		"ast",
-		"print"
-	],
+	"keywords": ["svelte", "ast", "print"],
 	"license": "MIT",
 	"author": {
 		"name": "Mateusz Kadlubowski",
@@ -38,10 +34,7 @@
 	"engines": {
 		"node": ">=20"
 	},
-	"files": [
-		"src/",
-		"types/"
-	],
+	"files": ["src/", "types/"],
 	"imports": {
 		"#tests/*": {
 			"types": "./tests/*.ts",
@@ -124,7 +117,6 @@
 		"all-contributors-cli": "6.26.1",
 		"auto": "11.2.0",
 		"del-cli": "5.1.0",
-		"lefthook": "1.7.14",
 		"markdownlint-cli2": "0.13.0",
 		"serve": "14.2.3",
 		"typedoc": "0.26.6",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -48,9 +48,6 @@ importers:
       del-cli:
         specifier: 5.1.0
         version: 5.1.0
-      lefthook:
-        specifier: 1.7.14
-        version: 1.7.14
       markdownlint-cli2:
         specifier: 0.13.0
         version: 0.13.0
@@ -2374,60 +2371,6 @@ packages:
   kleur@4.1.5:
     resolution: {integrity: sha512-o+NO+8WrRiQEE4/7nwRJhN1HWpVmJm511pBHUxPLtp0BUISzlBplORYSmTclCnJvQq2tKu/sgl3xVpkc7ZWuQQ==}
     engines: {node: '>=6'}
-
-  lefthook-darwin-arm64@1.7.14:
-    resolution: {integrity: sha512-3hNr04A8DSYZk0RBTdu8D/kkE3FHiNnexAEvuFOqLuf3EQhrrX1wxclGO0+tIk3s7nyh+iqpV69Xd+cb4Fnvpw==}
-    cpu: [arm64]
-    os: [darwin]
-
-  lefthook-darwin-x64@1.7.14:
-    resolution: {integrity: sha512-cXVsxTS2IRKKRyYFEMjAxf0a/31M1PkiNAjlJPXQPoAxxC1rbsvkxWL8vXhH4P0AL18zSYVBf9aTktYArgQGuA==}
-    cpu: [x64]
-    os: [darwin]
-
-  lefthook-freebsd-arm64@1.7.14:
-    resolution: {integrity: sha512-rhx2ZkbWD6SkOXLc5/xyN1fu0uL9MLYBYKKg5T0rLRVwqqr9aYKZ+1Rru/5oL8utH1qkQyiwQkcjnKkyHwSjPg==}
-    cpu: [arm64]
-    os: [freebsd]
-
-  lefthook-freebsd-x64@1.7.14:
-    resolution: {integrity: sha512-WeVPDm7JB1Crchc7OQ3uLiRfLlhwwX3N2662DPguMresps2r79dUO97LhHMzd+l1RKIqZIgnU+j5fKFI+cmw4w==}
-    cpu: [x64]
-    os: [freebsd]
-
-  lefthook-linux-arm64@1.7.14:
-    resolution: {integrity: sha512-IUvxJBfLDVComNc1Djk4VYUJsSAtdwfTvwpNxfaG2qb31VNvF6PPdp43bgpgqzV8O0KDCMm/sn0hlZ00GTuy2A==}
-    cpu: [arm64]
-    os: [linux]
-
-  lefthook-linux-x64@1.7.14:
-    resolution: {integrity: sha512-jCNjVk+9iaFSwlFH4RM7SI05tpdty0vPzSTsABXUQwdmKdt1hPWhnUsEhCU03ik33UmpfmXUK9pLFgStT7W5rw==}
-    cpu: [x64]
-    os: [linux]
-
-  lefthook-openbsd-arm64@1.7.14:
-    resolution: {integrity: sha512-Mq5GgjzDMiFin+Ucm52nizvvDQM1o+MnL/P+FDbBq253BIJGDJK+qEuQBgEQndE9bUyAP4qiHb+R6jz5fbpAlA==}
-    cpu: [arm64]
-    os: [openbsd]
-
-  lefthook-openbsd-x64@1.7.14:
-    resolution: {integrity: sha512-enbPte9MAYU2JHkcvUBRJrXI6JMVcQqJHN+F8yKOJLFBnthoR0ZUuSTzqAMOivj/wgncHkYPqOWIo1UfB+HpGw==}
-    cpu: [x64]
-    os: [openbsd]
-
-  lefthook-windows-arm64@1.7.14:
-    resolution: {integrity: sha512-M9QbTs+Je0SRKC2c/0X8OQsme6glFrKxQoxWMFCN02S6nNLiHqP4vsHphJFU+wnAwv4KE8I1YKT5iMxde0Ejlg==}
-    cpu: [arm64]
-    os: [win32]
-
-  lefthook-windows-x64@1.7.14:
-    resolution: {integrity: sha512-40Mx+a44kPZUF/AXV45EIgw03FANTXMFDBR1Ib8qYbSaf1cWqJtfeQs9R5Ea0EdqxXkGprzwZ+yUFFjjfOFIoQ==}
-    cpu: [x64]
-    os: [win32]
-
-  lefthook@1.7.14:
-    resolution: {integrity: sha512-GIMJm3HPksrHyXgu9OYX3r9QKM10hxoeiI45+7KhJKvAWChDtGqMZ5EPQuTMVsXu5IwggQL9QJLhDfk54WOXEw==}
-    hasBin: true
 
   lilconfig@3.1.2:
     resolution: {integrity: sha512-eop+wDAvpItUys0FWkHIKeC9ybYrTGbU41U5K7+bttZZeohvnY7M9dZ5kB21GNWiFT2q1OoPTvncPCgSOVO5ow==}
@@ -6528,50 +6471,6 @@ snapshots:
     optional: true
 
   kleur@4.1.5: {}
-
-  lefthook-darwin-arm64@1.7.14:
-    optional: true
-
-  lefthook-darwin-x64@1.7.14:
-    optional: true
-
-  lefthook-freebsd-arm64@1.7.14:
-    optional: true
-
-  lefthook-freebsd-x64@1.7.14:
-    optional: true
-
-  lefthook-linux-arm64@1.7.14:
-    optional: true
-
-  lefthook-linux-x64@1.7.14:
-    optional: true
-
-  lefthook-openbsd-arm64@1.7.14:
-    optional: true
-
-  lefthook-openbsd-x64@1.7.14:
-    optional: true
-
-  lefthook-windows-arm64@1.7.14:
-    optional: true
-
-  lefthook-windows-x64@1.7.14:
-    optional: true
-
-  lefthook@1.7.14:
-    optionalDependencies:
-      lefthook-darwin-arm64: 1.7.14
-      lefthook-darwin-x64: 1.7.14
-      lefthook-freebsd-arm64: 1.7.14
-      lefthook-freebsd-x64: 1.7.14
-      lefthook-linux-arm64: 1.7.14
-      lefthook-linux-x64: 1.7.14
-      lefthook-openbsd-arm64: 1.7.14
-      lefthook-openbsd-x64: 1.7.14
-      lefthook-windows-arm64: 1.7.14
-      lefthook-windows-x64: 1.7.14
-    optional: true
 
   lilconfig@3.1.2: {}
 


### PR DESCRIPTION
Is too invasive. It attempts to auto-install on the projects which
doesn't use it, but one of the dependencies uses it.
