### PR TITLE
feat: Allow Node v18

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
 		"provenance": true
 	},
 	"engines": {
-		"node": ">=20"
+		"node": ">=18"
 	},
 	"files": [
 		"src/",

--- a/package.json
+++ b/package.json
@@ -4,11 +4,7 @@
 	"version": "0.2.6",
 	"type": "module",
 	"description": "Print Svelte AST nodes as a string. Aka parse in reverse.",
-	"keywords": [
-		"svelte",
-		"ast",
-		"print"
-	],
+	"keywords": ["svelte", "ast", "print"],
 	"license": "MIT",
 	"author": {
 		"name": "Mateusz Kadlubowski",
@@ -38,10 +34,7 @@
 	"engines": {
 		"node": ">=18"
 	},
-	"files": [
-		"src/",
-		"types/"
-	],
+	"files": ["src/", "types/"],
 	"imports": {
 		"#tests/*": {
 			"types": "./tests/*.ts",


### PR DESCRIPTION
It would be great if we could allow Node v18+ in the `engines` field. Node v18 is still LTS and therefore it's what Svelte 5 supports as well as Storybook 8:

https://github.com/sveltejs/svelte/blob/main/packages/svelte/package.json#L8-L10

https://github.com/storybookjs/storybook/blob/5edc05ea9bd2d5c6c6267cf93818bdb1958df9ba/code/renderers/svelte/package.json#L79-L81

I have no idea if this package actually requires any Node v20-specific APIs?

Currently, when running `npm install` in a fresh SvelteKit + Storybook + Svelte CSF addon v5 + Node 18 you get the following error:

```
npm install
npm warn ERESOLVE overriding peer dependency
npm error code EBADENGINE
npm error engine Unsupported engine
npm error engine Not compatible with your version of node/npm: svelte-ast-print@0.2.6
npm error notsup Not compatible with your version of node/npm: svelte-ast-print@0.2.6
npm error notsup Required: {"node":">=20"}
npm error notsup Actual:   {"npm":"10.8.3","node":"v18.20.2"}
npm error A complete log of this run can be found in: /Users/jeppe/.npm/_logs/2024-10-24T19_41_35_770Z-debug-0.log                                                                                          /5.4s
```