### PR TITLE
fix: Crash caused by indentation logic inside `IfBlock`

### DIFF
--- a/.all-contributorsrc
+++ b/.all-contributorsrc
@@ -1,47 +1,35 @@
 {
-  "projectName": "svelte-ast-print",
-  "projectOwner": "xeho91",
-  "repoType": "github",
-  "repoHost": "https://github.com",
-  "files": [
-    "README.md"
-  ],
-  "imageSize": 100,
-  "commit": false,
-  "commitConvention": "none",
-  "contributors": [
-    {
-      "login": "xeho91",
-      "name": "Mateusz Kadlubowski",
-      "avatar_url": "https://avatars.githubusercontent.com/u/18627568?v=4",
-      "profile": "https://github.com/xeho91",
-      "contributions": [
-        "code",
-        "maintenance",
-        "doc",
-        "infra",
-        "test"
-      ]
-    },
-    {
-      "login": "manuel3108",
-      "name": "Manuel",
-      "avatar_url": "https://avatars.githubusercontent.com/u/30698007?v=4",
-      "profile": "https://github.com/manuel3108",
-      "contributions": [
-        "doc"
-      ]
-    },
-    {
-      "login": "JReinhold",
-      "name": "Jeppe Reinhold",
-      "avatar_url": "https://avatars.githubusercontent.com/u/5678122?v=4",
-      "profile": "https://reinhold.is/",
-      "contributions": [
-        "code"
-      ]
-    }
-  ],
-  "contributorsPerLine": 7,
-  "linkToUsage": false
+	"projectName": "svelte-ast-print",
+	"projectOwner": "xeho91",
+	"repoType": "github",
+	"repoHost": "https://github.com",
+	"files": ["README.md"],
+	"imageSize": 100,
+	"commit": false,
+	"commitConvention": "none",
+	"contributors": [
+		{
+			"login": "xeho91",
+			"name": "Mateusz Kadlubowski",
+			"avatar_url": "https://avatars.githubusercontent.com/u/18627568?v=4",
+			"profile": "https://github.com/xeho91",
+			"contributions": ["code", "maintenance", "doc", "infra", "test"]
+		},
+		{
+			"login": "manuel3108",
+			"name": "Manuel",
+			"avatar_url": "https://avatars.githubusercontent.com/u/30698007?v=4",
+			"profile": "https://github.com/manuel3108",
+			"contributions": ["doc"]
+		},
+		{
+			"login": "JReinhold",
+			"name": "Jeppe Reinhold",
+			"avatar_url": "https://avatars.githubusercontent.com/u/5678122?v=4",
+			"profile": "https://reinhold.is/",
+			"contributions": ["code"]
+		}
+	],
+	"contributorsPerLine": 7,
+	"linkToUsage": false
 }

--- a/package.json
+++ b/package.json
@@ -4,11 +4,7 @@
 	"version": "0.3.0",
 	"type": "module",
 	"description": "Print Svelte AST nodes as a string. Aka parse in reverse.",
-	"keywords": [
-		"svelte",
-		"ast",
-		"print"
-	],
+	"keywords": ["svelte", "ast", "print"],
 	"license": "MIT",
 	"author": {
 		"name": "Mateusz Kadlubowski",
@@ -38,10 +34,7 @@
 	"engines": {
 		"node": ">=18"
 	},
-	"files": [
-		"src/",
-		"types/"
-	],
+	"files": ["src/", "types/"],
 	"imports": {
 		"#tests/*": {
 			"types": "./tests/*.ts",

--- a/src/mod.js
+++ b/src/mod.js
@@ -970,20 +970,37 @@ class Printer {
 				if (elseif) {
 					state.#depth--;
 					state.#print_block_middle_tag("else if", print_es(test).code);
+					// FIXME: Temporary workaround - needs refactor when working on formatting features
+					if (consequent.nodes.length === 1 && consequent.nodes[0].type === "Text") {
+						consequent.nodes[0].raw = consequent.nodes[0].raw.replace(/\n/g, "");
+					}
 					state.#print_block_fragment(consequent, context);
 					if (alternate) {
 						if (!has_alternate_else_if(alternate)) {
+							// FIXME: Temporary workaround - needs refactor when working on formatting features
+							state.#print_new_line();
 							state.#print_block_middle_tag("else");
+						}
+						// FIXME: Temporary workaround - needs refactor when working on formatting features
+						if (alternate.nodes.length === 1 && alternate.nodes[0].type === "Text") {
+							alternate.nodes[0].raw = alternate.nodes[0].raw.replace(/\n/g, "");
 						}
 						state.#print_block_fragment(alternate, context);
 					}
 					state.#depth++;
 				} else {
 					state.#print_block_opening_tag("if", print_es(test).code);
+					// FIXME: Temporary workaround - needs refactor when working on formatting features
+					if (consequent.nodes.length === 1 && consequent.nodes[0].type === "Text") {
+						consequent.nodes[0].raw = consequent.nodes[0].raw.replace(/\n/g, "");
+					}
 					state.#print_block_fragment(consequent, context);
 					if (alternate) {
 						if (!has_alternate_else_if(alternate)) {
 							state.#print_block_middle_tag("else");
+						}
+						if (alternate.nodes.length === 1 && alternate.nodes[0].type === "Text") {
+							alternate.nodes[0].raw = alternate.nodes[0].raw.replace(/\n/g, "");
 						}
 						state.#print_block_fragment(alternate, context);
 					}

--- a/src/mod.js
+++ b/src/mod.js
@@ -968,7 +968,7 @@ class Printer {
 				/** @param {SvelteAST.Fragment} node */
 				const has_alternate_else_if = (node) => node.nodes.some((n) => n.type === "IfBlock");
 				if (elseif) {
-					if (state.#depth > 0) state.#depth--;
+					state.#depth--;
 					state.#print_block_middle_tag("else if", print_es(test).code);
 					state.#print_block_fragment(consequent, context);
 					if (alternate) {
@@ -977,6 +977,7 @@ class Printer {
 						}
 						state.#print_block_fragment(alternate, context);
 					}
+					state.#depth++;
 				} else {
 					state.#print_block_opening_tag("if", print_es(test).code);
 					state.#print_block_fragment(consequent, context);

--- a/tests/nodes/block.test.ts
+++ b/tests/nodes/block.test.ts
@@ -308,7 +308,7 @@ describe("IfBlock", () => {
 		`);
 	});
 
-	it("correctly prints {#if} block with multiple {:else if} and {:else}", ({ expect }) => {
+	it("correctly prints {#if} block with multiple {:else if} and {:else} - case with element-likes", ({ expect }) => {
 		const code = `
 			{#if test1}
 				<span>if body</span>
@@ -330,6 +330,31 @@ describe("IfBlock", () => {
 				<span>else if body2</span>
 			{:else}
 				<span>else body</span>
+			{/if}"
+		`);
+	});
+	it("correctly prints {#if} block with multiple {:else if} and {:else} - case with text only", ({ expect }) => {
+		const code = `
+			{#if test1}
+				if body
+			{:else if test2}
+				1else if body
+			{:else if test3}
+				2else if body
+			{:else}
+				else body
+			{/if}
+		`;
+		const node = parse_and_extract_svelte_node<IfBlock>(code, "IfBlock");
+		expect(print(node)).toMatchInlineSnapshot(`
+			"{#if test1}
+				if body
+			{:else if test2}
+				1else if body
+			{:else if test3}
+				2else if body
+			{:else}
+				else body
 			{/if}"
 		`);
 	});


### PR DESCRIPTION

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>0.3.1--canary.99.11578187003.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install svelte-ast-print@0.3.1--canary.99.11578187003.0
  # or 
  yarn add svelte-ast-print@0.3.1--canary.99.11578187003.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
