### PR TITLE
fix(dependencies): move optionalDependencies to devDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,11 +4,7 @@
 	"version": "0.4.0",
 	"type": "module",
 	"description": "Print Svelte AST nodes as a string. Aka parse in reverse.",
-	"keywords": [
-		"svelte",
-		"ast",
-		"print"
-	],
+	"keywords": ["svelte", "ast", "print"],
 	"license": "MIT",
 	"author": {
 		"name": "Mateusz Kadlubowski",
@@ -38,10 +34,7 @@
 	"engines": {
 		"node": ">=18"
 	},
-	"files": [
-		"src/",
-		"types/"
-	],
+	"files": ["src/", "types/"],
 	"imports": {
 		"#tests/*": {
 			"types": "./tests/*.ts",

--- a/package.json
+++ b/package.json
@@ -98,35 +98,33 @@
 		"zimmerframe": "1.1.2"
 	},
 	"devDependencies": {
-		"@total-typescript/ts-reset": "0.6.1",
-		"@total-typescript/tsconfig": "1.0.4",
-		"@types/estree": "1.0.6",
-		"@types/node": "22.8.4",
-		"dedent": "1.5.3",
-		"dts-buddy": "0.5.3",
-		"svelte": "5.1.4",
-		"type-fest": "4.26.1",
-		"typescript": "5.6.3"
-	},
-	"peerDependencies": {
-		"svelte": "^5.0.0"
-	},
-	"optionalDependencies": {
 		"@auto-it/all-contributors": "11.3.0",
 		"@auto-it/conventional-commits": "11.3.0",
 		"@auto-it/first-time-contributor": "11.3.0",
 		"@auto-it/npm": "11.3.0",
 		"@auto-it/released": "11.3.0",
 		"@biomejs/biome": "1.9.4",
+		"@total-typescript/ts-reset": "0.6.1",
+		"@total-typescript/tsconfig": "1.0.4",
+		"@types/estree": "1.0.6",
+		"@types/node": "22.8.4",
 		"@vitest/coverage-v8": "2.1.4",
 		"@vitest/ui": "2.1.4",
 		"all-contributors-cli": "6.26.1",
 		"auto": "11.3.0",
+		"dedent": "1.5.3",
+		"dts-buddy": "0.5.3",
 		"markdownlint-cli2": "0.14.0",
 		"serve": "14.2.4",
+		"svelte": "5.1.4",
+		"type-fest": "4.26.1",
 		"typedoc": "0.26.10",
 		"typedoc-plugin-coverage": "3.3.0",
 		"typedoc-plugin-mdn-links": "3.3.5",
+		"typescript": "5.6.3",
 		"vitest": "2.1.4"
+	},
+	"peerDependencies": {
+		"svelte": "^5.0.0"
 	}
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -14,7 +14,7 @@ importers:
       zimmerframe:
         specifier: 1.1.2
         version: 1.1.2
-    optionalDependencies:
+    devDependencies:
       '@auto-it/all-contributors':
         specifier: 11.3.0
         version: 11.3.0(@types/node@22.8.4)(typescript@5.6.3)
@@ -33,37 +33,6 @@ importers:
       '@biomejs/biome':
         specifier: 1.9.4
         version: 1.9.4
-      '@vitest/coverage-v8':
-        specifier: 2.1.4
-        version: 2.1.4(vitest@2.1.4(@types/node@22.8.4)(@vitest/ui@2.1.4))
-      '@vitest/ui':
-        specifier: 2.1.4
-        version: 2.1.4(vitest@2.1.4)
-      all-contributors-cli:
-        specifier: 6.26.1
-        version: 6.26.1
-      auto:
-        specifier: 11.3.0
-        version: 11.3.0(@types/node@22.8.4)(typescript@5.6.3)
-      markdownlint-cli2:
-        specifier: 0.14.0
-        version: 0.14.0
-      serve:
-        specifier: 14.2.4
-        version: 14.2.4
-      typedoc:
-        specifier: 0.26.10
-        version: 0.26.10(typescript@5.6.3)
-      typedoc-plugin-coverage:
-        specifier: 3.3.0
-        version: 3.3.0(typedoc@0.26.10(typescript@5.6.3))
-      typedoc-plugin-mdn-links:
-        specifier: 3.3.5
-        version: 3.3.5(typedoc@0.26.10(typescript@5.6.3))
-      vitest:
-        specifier: 2.1.4
-        version: 2.1.4(@types/node@22.8.4)(@vitest/ui@2.1.4)
-    devDependencies:
       '@total-typescript/ts-reset':
         specifier: 0.6.1
         version: 0.6.1
@@ -76,21 +45,51 @@ importers:
       '@types/node':
         specifier: 22.8.4
         version: 22.8.4
+      '@vitest/coverage-v8':
+        specifier: 2.1.4
+        version: 2.1.4(vitest@2.1.4(@types/node@22.8.4)(@vitest/ui@2.1.4))
+      '@vitest/ui':
+        specifier: 2.1.4
+        version: 2.1.4(vitest@2.1.4)
+      all-contributors-cli:
+        specifier: 6.26.1
+        version: 6.26.1
+      auto:
+        specifier: 11.3.0
+        version: 11.3.0(@types/node@22.8.4)(typescript@5.6.3)
       dedent:
         specifier: 1.5.3
         version: 1.5.3
       dts-buddy:
         specifier: 0.5.3
         version: 0.5.3(typescript@5.6.3)
+      markdownlint-cli2:
+        specifier: 0.14.0
+        version: 0.14.0
+      serve:
+        specifier: 14.2.4
+        version: 14.2.4
       svelte:
         specifier: 5.1.4
         version: 5.1.4
       type-fest:
         specifier: 4.26.1
         version: 4.26.1
+      typedoc:
+        specifier: 0.26.10
+        version: 0.26.10(typescript@5.6.3)
+      typedoc-plugin-coverage:
+        specifier: 3.3.0
+        version: 3.3.0(typedoc@0.26.10(typescript@5.6.3))
+      typedoc-plugin-mdn-links:
+        specifier: 3.3.5
+        version: 3.3.5(typedoc@0.26.10(typescript@5.6.3))
       typescript:
         specifier: 5.6.3
         version: 5.6.3
+      vitest:
+        specifier: 2.1.4
+        version: 2.1.4(@types/node@22.8.4)(@vitest/ui@2.1.4)
 
   libs/color:
     dependencies:
@@ -3490,10 +3489,8 @@ snapshots:
       - encoding
       - supports-color
       - typescript
-    optional: true
 
-  '@auto-it/bot-list@11.3.0':
-    optional: true
+  '@auto-it/bot-list@11.3.0': {}
 
   '@auto-it/conventional-commits@11.3.0(@types/node@22.8.4)(typescript@5.6.3)':
     dependencies:
@@ -3513,7 +3510,6 @@ snapshots:
       - encoding
       - supports-color
       - typescript
-    optional: true
 
   '@auto-it/core@11.3.0(@types/node@22.8.4)(typescript@5.6.3)':
     dependencies:
@@ -3565,7 +3561,6 @@ snapshots:
       - '@swc/wasm'
       - encoding
       - supports-color
-    optional: true
 
   '@auto-it/first-time-contributor@11.3.0(@types/node@22.8.4)(typescript@5.6.3)':
     dependencies:
@@ -3582,7 +3577,6 @@ snapshots:
       - encoding
       - supports-color
       - typescript
-    optional: true
 
   '@auto-it/npm@11.3.0(@types/node@22.8.4)(typescript@5.6.3)':
     dependencies:
@@ -3607,13 +3601,11 @@ snapshots:
       - encoding
       - supports-color
       - typescript
-    optional: true
 
   '@auto-it/package-json-utils@11.3.0':
     dependencies:
       parse-author: 2.0.0
       parse-github-url: 1.0.2
-    optional: true
 
   '@auto-it/released@11.3.0(@types/node@22.8.4)(typescript@5.6.3)':
     dependencies:
@@ -3630,7 +3622,6 @@ snapshots:
       - encoding
       - supports-color
       - typescript
-    optional: true
 
   '@auto-it/version-file@11.3.0(@types/node@22.8.4)(typescript@5.6.3)':
     dependencies:
@@ -3646,44 +3637,35 @@ snapshots:
       - encoding
       - supports-color
       - typescript
-    optional: true
 
   '@babel/code-frame@7.26.0':
     dependencies:
       '@babel/helper-validator-identifier': 7.25.9
       js-tokens: 4.0.0
       picocolors: 1.1.1
-    optional: true
 
-  '@babel/helper-string-parser@7.25.9':
-    optional: true
+  '@babel/helper-string-parser@7.25.9': {}
 
-  '@babel/helper-validator-identifier@7.25.9':
-    optional: true
+  '@babel/helper-validator-identifier@7.25.9': {}
 
   '@babel/parser@7.26.1':
     dependencies:
       '@babel/types': 7.26.0
-    optional: true
 
   '@babel/runtime@7.24.7':
     dependencies:
       regenerator-runtime: 0.14.1
-    optional: true
 
   '@babel/runtime@7.26.0':
     dependencies:
       regenerator-runtime: 0.14.1
-    optional: true
 
   '@babel/types@7.26.0':
     dependencies:
       '@babel/helper-string-parser': 7.25.9
       '@babel/helper-validator-identifier': 7.25.9
-    optional: true
 
-  '@bcoe/v8-coverage@0.2.3':
-    optional: true
+  '@bcoe/v8-coverage@0.2.3': {}
 
   '@biomejs/biome@1.9.4':
     optionalDependencies:
@@ -3695,7 +3677,6 @@ snapshots:
       '@biomejs/cli-linux-x64-musl': 1.9.4
       '@biomejs/cli-win32-arm64': 1.9.4
       '@biomejs/cli-win32-x64': 1.9.4
-    optional: true
 
   '@biomejs/cli-darwin-arm64@1.9.4':
     optional: true
@@ -3724,7 +3705,6 @@ snapshots:
   '@cspotcode/source-map-support@0.8.1':
     dependencies:
       '@jridgewell/trace-mapping': 0.3.9
-    optional: true
 
   '@endemolshinegroup/cosmiconfig-typescript-loader@3.0.2(cosmiconfig@7.0.0)(typescript@5.6.3)':
     dependencies:
@@ -3735,7 +3715,6 @@ snapshots:
       tslib: 2.1.0
     transitivePeerDependencies:
       - typescript
-    optional: true
 
   '@esbuild/aix-ppc64@0.21.5':
     optional: true
@@ -3806,8 +3785,7 @@ snapshots:
   '@esbuild/win32-x64@0.21.5':
     optional: true
 
-  '@hutson/parse-repository-url@3.0.2':
-    optional: true
+  '@hutson/parse-repository-url@3.0.2': {}
 
   '@isaacs/cliui@8.0.2':
     dependencies:
@@ -3817,10 +3795,8 @@ snapshots:
       strip-ansi-cjs: strip-ansi@6.0.1
       wrap-ansi: 8.1.0
       wrap-ansi-cjs: wrap-ansi@7.0.0
-    optional: true
 
-  '@istanbuljs/schema@0.1.3':
-    optional: true
+  '@istanbuljs/schema@0.1.3': {}
 
   '@jridgewell/gen-mapping@0.3.5':
     dependencies:
@@ -3850,27 +3826,22 @@ snapshots:
     dependencies:
       '@jridgewell/resolve-uri': 3.1.2
       '@jridgewell/sourcemap-codec': 1.5.0
-    optional: true
 
   '@nodelib/fs.scandir@2.1.5':
     dependencies:
       '@nodelib/fs.stat': 2.0.5
       run-parallel: 1.2.0
-    optional: true
 
-  '@nodelib/fs.stat@2.0.5':
-    optional: true
+  '@nodelib/fs.stat@2.0.5': {}
 
   '@nodelib/fs.walk@1.2.8':
     dependencies:
       '@nodelib/fs.scandir': 2.1.5
       fastq: 1.17.1
-    optional: true
 
   '@octokit/auth-token@2.5.0':
     dependencies:
       '@octokit/types': 6.41.0
-    optional: true
 
   '@octokit/core@3.6.0':
     dependencies:
@@ -3883,14 +3854,12 @@ snapshots:
       universal-user-agent: 6.0.1
     transitivePeerDependencies:
       - encoding
-    optional: true
 
   '@octokit/endpoint@6.0.12':
     dependencies:
       '@octokit/types': 6.41.0
       is-plain-object: 5.0.0
       universal-user-agent: 6.0.1
-    optional: true
 
   '@octokit/graphql@4.8.0':
     dependencies:
@@ -3899,54 +3868,45 @@ snapshots:
       universal-user-agent: 6.0.1
     transitivePeerDependencies:
       - encoding
-    optional: true
 
-  '@octokit/openapi-types@12.11.0':
-    optional: true
+  '@octokit/openapi-types@12.11.0': {}
 
   '@octokit/plugin-enterprise-compatibility@1.3.0':
     dependencies:
       '@octokit/request-error': 2.1.0
       '@octokit/types': 6.41.0
-    optional: true
 
   '@octokit/plugin-paginate-rest@2.21.3(@octokit/core@3.6.0)':
     dependencies:
       '@octokit/core': 3.6.0
       '@octokit/types': 6.41.0
-    optional: true
 
   '@octokit/plugin-request-log@1.0.4(@octokit/core@3.6.0)':
     dependencies:
       '@octokit/core': 3.6.0
-    optional: true
 
   '@octokit/plugin-rest-endpoint-methods@5.16.2(@octokit/core@3.6.0)':
     dependencies:
       '@octokit/core': 3.6.0
       '@octokit/types': 6.41.0
       deprecation: 2.3.1
-    optional: true
 
   '@octokit/plugin-retry@3.0.9':
     dependencies:
       '@octokit/types': 6.41.0
       bottleneck: 2.19.5
-    optional: true
 
   '@octokit/plugin-throttling@3.7.0(@octokit/core@3.6.0)':
     dependencies:
       '@octokit/core': 3.6.0
       '@octokit/types': 6.41.0
       bottleneck: 2.19.5
-    optional: true
 
   '@octokit/request-error@2.1.0':
     dependencies:
       '@octokit/types': 6.41.0
       deprecation: 2.3.1
       once: 1.4.0
-    optional: true
 
   '@octokit/request@5.6.3':
     dependencies:
@@ -3958,7 +3918,6 @@ snapshots:
       universal-user-agent: 6.0.1
     transitivePeerDependencies:
       - encoding
-    optional: true
 
   '@octokit/rest@18.12.0':
     dependencies:
@@ -3968,18 +3927,15 @@ snapshots:
       '@octokit/plugin-rest-endpoint-methods': 5.16.2(@octokit/core@3.6.0)
     transitivePeerDependencies:
       - encoding
-    optional: true
 
   '@octokit/types@6.41.0':
     dependencies:
       '@octokit/openapi-types': 12.11.0
-    optional: true
 
   '@pkgjs/parseargs@0.11.0':
     optional: true
 
-  '@polka/url@1.0.0-next.28':
-    optional: true
+  '@polka/url@1.0.0-next.28': {}
 
   '@radix-ui/colors@3.0.0': {}
 
@@ -4098,32 +4054,26 @@ snapshots:
       '@shikijs/vscode-textmate': 9.3.0
       '@types/hast': 3.0.4
       hast-util-to-html: 9.0.3
-    optional: true
 
   '@shikijs/engine-javascript@1.22.2':
     dependencies:
       '@shikijs/types': 1.22.2
       '@shikijs/vscode-textmate': 9.3.0
       oniguruma-to-js: 0.4.3
-    optional: true
 
   '@shikijs/engine-oniguruma@1.22.2':
     dependencies:
       '@shikijs/types': 1.22.2
       '@shikijs/vscode-textmate': 9.3.0
-    optional: true
 
   '@shikijs/types@1.22.2':
     dependencies:
       '@shikijs/vscode-textmate': 9.3.0
       '@types/hast': 3.0.4
-    optional: true
 
-  '@shikijs/vscode-textmate@9.3.0':
-    optional: true
+  '@shikijs/vscode-textmate@9.3.0': {}
 
-  '@sindresorhus/merge-streams@2.3.0':
-    optional: true
+  '@sindresorhus/merge-streams@2.3.0': {}
 
   '@storybook/channels@8.1.11':
     dependencies:
@@ -4160,28 +4110,22 @@ snapshots:
 
   '@total-typescript/tsconfig@1.0.4': {}
 
-  '@tsconfig/node10@1.0.11':
-    optional: true
+  '@tsconfig/node10@1.0.11': {}
 
-  '@tsconfig/node12@1.0.11':
-    optional: true
+  '@tsconfig/node12@1.0.11': {}
 
-  '@tsconfig/node14@1.0.3':
-    optional: true
+  '@tsconfig/node14@1.0.3': {}
 
-  '@tsconfig/node16@1.0.4':
-    optional: true
+  '@tsconfig/node16@1.0.4': {}
 
   '@types/body-parser@1.19.5':
     dependencies:
       '@types/connect': 3.4.38
       '@types/node': 20.14.7
 
-  '@types/command-line-args@5.2.3':
-    optional: true
+  '@types/command-line-args@5.2.3': {}
 
-  '@types/command-line-usage@5.0.4':
-    optional: true
+  '@types/command-line-usage@5.0.4': {}
 
   '@types/connect@3.4.38':
     dependencies:
@@ -4210,19 +4154,16 @@ snapshots:
   '@types/hast@3.0.4':
     dependencies:
       '@types/unist': 3.0.3
-    optional: true
 
   '@types/http-errors@2.0.4': {}
 
   '@types/mdast@4.0.4':
     dependencies:
       '@types/unist': 3.0.3
-    optional: true
 
   '@types/mime@1.3.5': {}
 
-  '@types/minimist@1.2.5':
-    optional: true
+  '@types/minimist@1.2.5': {}
 
   '@types/node@20.14.7':
     dependencies:
@@ -4232,11 +4173,9 @@ snapshots:
     dependencies:
       undici-types: 6.19.8
 
-  '@types/normalize-package-data@2.4.4':
-    optional: true
+  '@types/normalize-package-data@2.4.4': {}
 
-  '@types/parse-json@4.0.2':
-    optional: true
+  '@types/parse-json@4.0.2': {}
 
   '@types/qs@6.9.15': {}
 
@@ -4253,11 +4192,9 @@ snapshots:
       '@types/node': 20.14.7
       '@types/send': 0.17.4
 
-  '@types/unist@3.0.3':
-    optional: true
+  '@types/unist@3.0.3': {}
 
-  '@ungap/structured-clone@1.2.0':
-    optional: true
+  '@ungap/structured-clone@1.2.0': {}
 
   '@vitest/coverage-v8@2.1.4(vitest@2.1.4(@types/node@22.8.4)(@vitest/ui@2.1.4))':
     dependencies:
@@ -4276,7 +4213,6 @@ snapshots:
       vitest: 2.1.4(@types/node@22.8.4)(@vitest/ui@2.1.4)
     transitivePeerDependencies:
       - supports-color
-    optional: true
 
   '@vitest/expect@2.1.4':
     dependencies:
@@ -4284,7 +4220,6 @@ snapshots:
       '@vitest/utils': 2.1.4
       chai: 5.1.2
       tinyrainbow: 1.2.0
-    optional: true
 
   '@vitest/mocker@2.1.4(vite@5.4.10(@types/node@22.8.4))':
     dependencies:
@@ -4293,30 +4228,25 @@ snapshots:
       magic-string: 0.30.12
     optionalDependencies:
       vite: 5.4.10(@types/node@22.8.4)
-    optional: true
 
   '@vitest/pretty-format@2.1.4':
     dependencies:
       tinyrainbow: 1.2.0
-    optional: true
 
   '@vitest/runner@2.1.4':
     dependencies:
       '@vitest/utils': 2.1.4
       pathe: 1.1.2
-    optional: true
 
   '@vitest/snapshot@2.1.4':
     dependencies:
       '@vitest/pretty-format': 2.1.4
       magic-string: 0.30.12
       pathe: 1.1.2
-    optional: true
 
   '@vitest/spy@2.1.4':
     dependencies:
       tinyspy: 3.0.2
-    optional: true
 
   '@vitest/ui@2.1.4(vitest@2.1.4)':
     dependencies:
@@ -4328,23 +4258,19 @@ snapshots:
       tinyglobby: 0.2.10
       tinyrainbow: 1.2.0
       vitest: 2.1.4(@types/node@22.8.4)(@vitest/ui@2.1.4)
-    optional: true
 
   '@vitest/utils@2.1.4':
     dependencies:
       '@vitest/pretty-format': 2.1.4
       loupe: 3.1.2
       tinyrainbow: 1.2.0
-    optional: true
 
-  '@zeit/schemas@2.36.0':
-    optional: true
+  '@zeit/schemas@2.36.0': {}
 
   JSONStream@1.3.5:
     dependencies:
       jsonparse: 1.3.1
       through: 2.3.8
-    optional: true
 
   abort-controller@3.0.0:
     dependencies:
@@ -4354,7 +4280,6 @@ snapshots:
     dependencies:
       mime-types: 2.1.35
       negotiator: 0.6.3
-    optional: true
 
   acorn-typescript@1.4.13(acorn@8.12.0):
     dependencies:
@@ -4367,24 +4292,20 @@ snapshots:
   acorn-walk@8.3.4:
     dependencies:
       acorn: 8.14.0
-    optional: true
 
   acorn@8.12.0: {}
 
   acorn@8.12.1: {}
 
-  acorn@8.14.0:
-    optional: true
+  acorn@8.14.0: {}
 
-  add-stream@1.0.0:
-    optional: true
+  add-stream@1.0.0: {}
 
   agent-base@6.0.2:
     dependencies:
       debug: 4.3.7
     transitivePeerDependencies:
       - supports-color
-    optional: true
 
   ajv@8.12.0:
     dependencies:
@@ -4392,7 +4313,6 @@ snapshots:
       json-schema-traverse: 1.0.0
       require-from-string: 2.0.2
       uri-js: 4.4.1
-    optional: true
 
   all-contributors-cli@6.19.0:
     dependencies:
@@ -4408,7 +4328,6 @@ snapshots:
       yargs: 15.4.1
     transitivePeerDependencies:
       - encoding
-    optional: true
 
   all-contributors-cli@6.26.1:
     dependencies:
@@ -4426,57 +4345,43 @@ snapshots:
       prettier: 2.8.8
     transitivePeerDependencies:
       - encoding
-    optional: true
 
   ansi-align@3.0.1:
     dependencies:
       string-width: 4.2.3
-    optional: true
 
-  ansi-colors@4.1.3:
-    optional: true
+  ansi-colors@4.1.3: {}
 
   ansi-escapes@4.3.2:
     dependencies:
       type-fest: 0.21.3
-    optional: true
 
-  ansi-regex@5.0.1:
-    optional: true
+  ansi-regex@5.0.1: {}
 
-  ansi-regex@6.1.0:
-    optional: true
+  ansi-regex@6.1.0: {}
 
   ansi-styles@3.2.1:
     dependencies:
       color-convert: 1.9.3
-    optional: true
 
   ansi-styles@4.3.0:
     dependencies:
       color-convert: 2.0.1
-    optional: true
 
-  ansi-styles@6.2.1:
-    optional: true
+  ansi-styles@6.2.1: {}
 
   anymatch@3.1.3:
     dependencies:
       normalize-path: 3.0.0
       picomatch: 2.3.1
-    optional: true
 
-  arch@2.2.0:
-    optional: true
+  arch@2.2.0: {}
 
-  arg@4.1.3:
-    optional: true
+  arg@4.1.3: {}
 
-  arg@5.0.2:
-    optional: true
+  arg@5.0.2: {}
 
-  argparse@2.0.1:
-    optional: true
+  argparse@2.0.1: {}
 
   aria-query@5.3.0:
     dependencies:
@@ -4484,25 +4389,20 @@ snapshots:
 
   aria-query@5.3.2: {}
 
-  array-back@3.1.0:
-    optional: true
+  array-back@3.1.0: {}
 
-  array-back@4.0.2:
-    optional: true
+  array-back@4.0.2: {}
 
   array-buffer-byte-length@1.0.1:
     dependencies:
       call-bind: 1.0.7
       is-array-buffer: 3.0.4
-    optional: true
 
   array-union@1.0.2:
     dependencies:
       array-uniq: 1.0.3
-    optional: true
 
-  array-uniq@1.0.3:
-    optional: true
+  array-uniq@1.0.3: {}
 
   array.prototype.flatmap@1.3.2:
     dependencies:
@@ -4510,7 +4410,6 @@ snapshots:
       define-properties: 1.2.1
       es-abstract: 1.23.3
       es-shim-unscopables: 1.0.2
-    optional: true
 
   arraybuffer.prototype.slice@1.0.3:
     dependencies:
@@ -4522,24 +4421,18 @@ snapshots:
       get-intrinsic: 1.2.4
       is-array-buffer: 3.0.4
       is-shared-array-buffer: 1.0.3
-    optional: true
 
-  arrify@1.0.1:
-    optional: true
+  arrify@1.0.1: {}
 
-  assertion-error@2.0.1:
-    optional: true
+  assertion-error@2.0.1: {}
 
-  async@3.2.5:
-    optional: true
+  async@3.2.5: {}
 
-  async@3.2.6:
-    optional: true
+  async@3.2.6: {}
 
   atomic-sleep@1.0.0: {}
 
-  author-regex@1.0.0:
-    optional: true
+  author-regex@1.0.0: {}
 
   auto@11.3.0(@types/node@22.8.4)(typescript@5.6.3):
     dependencies:
@@ -4562,15 +4455,12 @@ snapshots:
       - encoding
       - supports-color
       - typescript
-    optional: true
 
   available-typed-arrays@1.0.7:
     dependencies:
       possible-typed-array-names: 1.0.0
-    optional: true
 
-  await-to-js@3.0.0:
-    optional: true
+  await-to-js@3.0.0: {}
 
   axobject-query@4.0.0:
     dependencies:
@@ -4578,16 +4468,13 @@ snapshots:
 
   axobject-query@4.1.0: {}
 
-  balanced-match@1.0.2:
-    optional: true
+  balanced-match@1.0.2: {}
 
   base64-js@1.5.1: {}
 
-  before-after-hook@2.2.3:
-    optional: true
+  before-after-hook@2.2.3: {}
 
-  bottleneck@2.19.5:
-    optional: true
+  bottleneck@2.19.5: {}
 
   boxen@7.0.0:
     dependencies:
@@ -4599,37 +4486,30 @@ snapshots:
       type-fest: 2.19.0
       widest-line: 4.0.1
       wrap-ansi: 8.1.0
-    optional: true
 
   brace-expansion@1.1.11:
     dependencies:
       balanced-match: 1.0.2
       concat-map: 0.0.1
-    optional: true
 
   brace-expansion@2.0.1:
     dependencies:
       balanced-match: 1.0.2
-    optional: true
 
   braces@3.0.3:
     dependencies:
       fill-range: 7.1.1
-    optional: true
 
-  buffer-from@1.1.2:
-    optional: true
+  buffer-from@1.1.2: {}
 
   buffer@6.0.3:
     dependencies:
       base64-js: 1.5.1
       ieee754: 1.2.1
 
-  bytes@3.0.0:
-    optional: true
+  bytes@3.0.0: {}
 
-  cac@6.7.14:
-    optional: true
+  cac@6.7.14: {}
 
   call-bind@1.0.7:
     dependencies:
@@ -4638,26 +4518,20 @@ snapshots:
       function-bind: 1.1.2
       get-intrinsic: 1.2.4
       set-function-length: 1.2.2
-    optional: true
 
-  callsites@3.1.0:
-    optional: true
+  callsites@3.1.0: {}
 
   camelcase-keys@6.2.2:
     dependencies:
       camelcase: 5.3.1
       map-obj: 4.3.0
       quick-lru: 4.0.1
-    optional: true
 
-  camelcase@5.3.1:
-    optional: true
+  camelcase@5.3.1: {}
 
-  camelcase@7.0.1:
-    optional: true
+  camelcase@7.0.1: {}
 
-  ccount@2.0.1:
-    optional: true
+  ccount@2.0.1: {}
 
   chai@5.1.2:
     dependencies:
@@ -4666,95 +4540,75 @@ snapshots:
       deep-eql: 5.0.2
       loupe: 3.1.2
       pathval: 2.0.0
-    optional: true
 
   chalk-template@0.4.0:
     dependencies:
       chalk: 4.1.2
-    optional: true
 
   chalk@2.4.2:
     dependencies:
       ansi-styles: 3.2.1
       escape-string-regexp: 1.0.5
       supports-color: 5.5.0
-    optional: true
 
   chalk@4.1.2:
     dependencies:
       ansi-styles: 4.3.0
       supports-color: 7.2.0
-    optional: true
 
-  chalk@5.0.1:
-    optional: true
+  chalk@5.0.1: {}
 
-  character-entities-html4@2.1.0:
-    optional: true
+  character-entities-html4@2.1.0: {}
 
-  character-entities-legacy@3.0.0:
-    optional: true
+  character-entities-legacy@3.0.0: {}
 
-  chardet@0.7.0:
-    optional: true
+  chardet@0.7.0: {}
 
-  check-error@2.1.1:
-    optional: true
+  check-error@2.1.1: {}
 
-  cli-boxes@3.0.0:
-    optional: true
+  cli-boxes@3.0.0: {}
 
   cli-cursor@3.1.0:
     dependencies:
       restore-cursor: 3.1.0
-    optional: true
 
-  cli-width@3.0.0:
-    optional: true
+  cli-width@3.0.0: {}
 
   clipboardy@3.0.0:
     dependencies:
       arch: 2.2.0
       execa: 5.1.1
       is-wsl: 2.2.0
-    optional: true
 
   cliui@6.0.0:
     dependencies:
       string-width: 4.2.3
       strip-ansi: 6.0.1
       wrap-ansi: 6.2.0
-    optional: true
 
   cliui@7.0.4:
     dependencies:
       string-width: 4.2.3
       strip-ansi: 6.0.1
       wrap-ansi: 7.0.0
-    optional: true
 
   clsx@2.1.1: {}
 
   color-convert@1.9.3:
     dependencies:
       color-name: 1.1.3
-    optional: true
 
   color-convert@2.0.1:
     dependencies:
       color-name: 1.1.4
-    optional: true
 
-  color-name@1.1.3:
-    optional: true
+  color-name@1.1.3: {}
 
-  color-name@1.1.4:
-    optional: true
+  color-name@1.1.4: {}
 
   colorette@2.0.20: {}
 
-  comma-separated-tokens@2.0.3:
-    optional: true
+  comma-separated-tokens@2.0.3: {}
 
   command-line-application@0.10.1:
     dependencies:
@@ -4766,7 +4620,6 @@ snapshots:
       meant: 1.0.3
       remove-markdown: 0.3.0
       tslib: 1.10.0
-    optional: true
 
   command-line-args@5.2.1:
     dependencies:
@@ -4774,7 +4627,6 @@ snapshots:
       find-replace: 3.0.0
       lodash.camelcase: 4.3.0
       typical: 4.0.0
-    optional: true
 
   command-line-usage@6.1.3:
     dependencies:
@@ -4782,12 +4634,10 @@ snapshots:
       chalk: 2.4.2
       table-layout: 1.0.2
       typical: 5.2.0
-    optional: true
 
   compressible@2.0.18:
     dependencies:
       mime-db: 1.53.0
-    optional: true
 
   compression@1.7.4:
     dependencies:
@@ -4800,13 +4650,10 @@ snapshots:
       vary: 1.1.2
     transitivePeerDependencies:
       - supports-color
-    optional: true
 
-  concat-map@0.0.1:
-    optional: true
+  concat-map@0.0.1: {}
 
-  content-disposition@0.5.2:
-    optional: true
+  content-disposition@0.5.2: {}
 
   conventional-changelog-core@4.2.4:
     dependencies:
@@ -4824,10 +4671,8 @@ snapshots:
       read-pkg: 3.0.0
       read-pkg-up: 3.0.0
       through2: 4.0.2
-    optional: true
 
-  conventional-changelog-preset-loader@2.3.4:
-    optional: true
+  conventional-changelog-preset-loader@2.3.4: {}
 
   conventional-changelog-writer@5.0.1:
     dependencies:
@@ -4840,13 +4685,11 @@ snapshots:
       semver: 6.3.1
       split: 1.0.1
       through2: 4.0.2
-    optional: true
 
   conventional-commits-filter@2.0.7:
     dependencies:
       lodash.ismatch: 4.4.0
       modify-values: 1.0.1
-    optional: true
 
   conventional-commits-parser@3.2.4:
     dependencies:
@@ -4856,10 +4699,8 @@ snapshots:
       meow: 8.1.2
       split2: 3.2.2
       through2: 4.0.2
-    optional: true
 
-  core-util-is@1.0.3:
-    optional: true
+  core-util-is@1.0.3: {}
 
   cosmiconfig@7.0.0:
     dependencies:
@@ -4868,119 +4709,95 @@ snapshots:
       parse-json: 5.2.0
       path-type: 4.0.0
       yaml: 1.10.2
-    optional: true
 
-  create-require@1.1.1:
-    optional: true
+  create-require@1.1.1: {}
 
   cross-spawn@7.0.3:
     dependencies:
       path-key: 3.1.1
       shebang-command: 2.0.0
       which: 2.0.2
-    optional: true
 
   culori@4.0.1: {}
 
-  dargs@7.0.0:
-    optional: true
+  dargs@7.0.0: {}
 
   data-view-buffer@1.0.1:
     dependencies:
       call-bind: 1.0.7
       es-errors: 1.3.0
       is-data-view: 1.0.1
-    optional: true
 
   data-view-byte-length@1.0.1:
     dependencies:
       call-bind: 1.0.7
       es-errors: 1.3.0
       is-data-view: 1.0.1
-    optional: true
 
   data-view-byte-offset@1.0.0:
     dependencies:
       call-bind: 1.0.7
       es-errors: 1.3.0
       is-data-view: 1.0.1
-    optional: true
 
-  dateformat@3.0.3:
-    optional: true
+  dateformat@3.0.3: {}
 
   dateformat@4.6.3: {}
 
   debug@2.6.9:
     dependencies:
       ms: 2.0.0
-    optional: true
 
   debug@4.3.7:
     dependencies:
       ms: 2.1.3
-    optional: true
 
   decamelize-keys@1.1.1:
     dependencies:
       decamelize: 1.2.0
       map-obj: 1.0.1
-    optional: true
 
-  decamelize@1.2.0:
-    optional: true
+  decamelize@1.2.0: {}
 
-  dedent@0.7.0:
-    optional: true
+  dedent@0.7.0: {}
 
   dedent@1.5.3: {}
 
-  deep-eql@5.0.2:
-    optional: true
+  deep-eql@5.0.2: {}
 
-  deep-extend@0.6.0:
-    optional: true
+  deep-extend@0.6.0: {}
 
-  deepmerge@4.3.1:
-    optional: true
+  deepmerge@4.3.1: {}
 
   define-data-property@1.1.4:
     dependencies:
       es-define-property: 1.0.0
       es-errors: 1.3.0
       gopd: 1.0.1
-    optional: true
 
   define-properties@1.2.1:
     dependencies:
       define-data-property: 1.1.4
       has-property-descriptors: 1.0.2
       object-keys: 1.1.1
-    optional: true
 
-  deprecation@2.3.1:
-    optional: true
+  deprecation@2.3.1: {}
 
   dequal@2.0.3: {}
 
   devlop@1.1.0:
     dependencies:
       dequal: 2.0.3
-    optional: true
 
-  didyoumean@1.2.2:
-    optional: true
+  didyoumean@1.2.2: {}
 
-  diff@4.0.2:
-    optional: true
+  diff@4.0.2: {}
 
   dir-glob@2.2.2:
     dependencies:
       path-type: 3.0.0
-    optional: true
 
-  dotenv@8.6.0:
-    optional: true
+  dotenv@8.6.0: {}
 
   dts-buddy@0.5.3(typescript@5.6.3):
     dependencies:
@@ -4995,14 +4812,11 @@ snapshots:
       ts-api-utils: 1.3.0(typescript@5.6.3)
       typescript: 5.6.3
 
-  eastasianwidth@0.2.0:
-    optional: true
+  eastasianwidth@0.2.0: {}
 
-  emoji-regex@8.0.0:
-    optional: true
+  emoji-regex@8.0.0: {}
 
-  emoji-regex@9.2.2:
-    optional: true
+  emoji-regex@9.2.2: {}
 
   end-of-stream@1.4.4:
     dependencies:
@@ -5013,28 +4827,23 @@ snapshots:
       dedent: 0.7.0
       fast-json-parse: 1.0.3
       objectorarray: 1.0.5
-    optional: true
 
   enquirer@2.4.1:
     dependencies:
       ansi-colors: 4.1.3
       strip-ansi: 6.0.1
-    optional: true
 
-  entities@4.5.0:
-    optional: true
+  entities@4.5.0: {}
 
   env-ci@5.5.0:
     dependencies:
       execa: 5.1.1
       fromentries: 1.3.2
       java-properties: 1.0.2
-    optional: true
 
   error-ex@1.3.2:
     dependencies:
       is-arrayish: 0.2.1
-    optional: true
 
   es-abstract@1.23.3:
     dependencies:
@@ -5084,39 +4893,32 @@ snapshots:
       typed-array-length: 1.0.6
       unbox-primitive: 1.0.2
       which-typed-array: 1.1.15
-    optional: true
 
   es-define-property@1.0.0:
     dependencies:
       get-intrinsic: 1.2.4
-    optional: true
 
-  es-errors@1.3.0:
-    optional: true
+  es-errors@1.3.0: {}
 
   es-object-atoms@1.0.0:
     dependencies:
       es-errors: 1.3.0
-    optional: true
 
   es-set-tostringtag@2.0.3:
     dependencies:
       get-intrinsic: 1.2.4
       has-tostringtag: 1.0.2
       hasown: 2.0.2
-    optional: true
 
   es-shim-unscopables@1.0.2:
     dependencies:
       hasown: 2.0.2
-    optional: true
 
   es-to-primitive@1.2.1:
     dependencies:
       is-callable: 1.2.7
       is-date-object: 1.0.5
       is-symbol: 1.0.4
-    optional: true
 
   esbuild@0.21.5:
     optionalDependencies:
@@ -5143,13 +4945,10 @@ snapshots:
       '@esbuild/win32-arm64': 0.21.5
       '@esbuild/win32-ia32': 0.21.5
       '@esbuild/win32-x64': 0.21.5
-    optional: true
 
-  escalade@3.2.0:
-    optional: true
+  escalade@3.2.0: {}
 
-  escape-string-regexp@1.0.5:
-    optional: true
+  escape-string-regexp@1.0.5: {}
 
   esm-env@1.0.0: {}
 
@@ -5163,7 +4962,6 @@ snapshots:
   estree-walker@3.0.3:
     dependencies:
       '@types/estree': 1.0.6
-    optional: true
 
   event-target-shim@5.0.1: {}
 
@@ -5180,22 +4978,18 @@ snapshots:
       onetime: 5.1.2
       signal-exit: 3.0.7
       strip-final-newline: 2.0.0
-    optional: true
 
-  expect-type@1.1.0:
-    optional: true
+  expect-type@1.1.0: {}
 
   external-editor@3.1.0:
     dependencies:
       chardet: 0.7.0
       iconv-lite: 0.4.24
       tmp: 0.0.33
-    optional: true
 
   fast-copy@3.0.2: {}
 
-  fast-deep-equal@3.1.3:
-    optional: true
+  fast-deep-equal@3.1.3: {}
 
   fast-glob@3.3.2:
     dependencies:
@@ -5204,10 +4998,8 @@ snapshots:
       glob-parent: 5.1.2
       merge2: 1.4.1
       micromatch: 4.0.8
-    optional: true
 
-  fast-json-parse@1.0.3:
-    optional: true
+  fast-json-parse@1.0.3: {}
 
   fast-redact@3.5.0: {}
 
@@ -5216,25 +5008,20 @@ snapshots:
   fastq@1.17.1:
     dependencies:
       reusify: 1.0.4
-    optional: true
 
   fdir@6.4.2(picomatch@4.0.2):
     optionalDependencies:
       picomatch: 4.0.2
-    optional: true
 
-  fflate@0.8.2:
-    optional: true
+  fflate@0.8.2: {}
 
   figures@2.0.0:
     dependencies:
       escape-string-regexp: 1.0.5
-    optional: true
 
   figures@3.2.0:
     dependencies:
       escape-string-regexp: 1.0.5
-    optional: true
 
   file-system-cache@2.3.0:
     dependencies:
@@ -5244,23 +5031,19 @@ snapshots:
   fill-range@7.1.1:
     dependencies:
       to-regex-range: 5.0.1
-    optional: true
 
   find-replace@3.0.0:
     dependencies:
       array-back: 3.1.0
-    optional: true
 
   find-up@2.1.0:
     dependencies:
       locate-path: 2.0.0
-    optional: true
 
   find-up@4.1.0:
     dependencies:
       locate-path: 5.0.0
       path-exists: 4.0.0
-    optional: true
 
   find-up@7.0.0:
     dependencies:
@@ -5268,25 +5051,20 @@ snapshots:
       path-exists: 5.0.0
       unicorn-magic: 0.1.0
 
-  flatted@3.3.1:
-    optional: true
+  flatted@3.3.1: {}
 
   for-each@0.3.3:
     dependencies:
       is-callable: 1.2.7
-    optional: true
 
   foreground-child@3.3.0:
     dependencies:
       cross-spawn: 7.0.3
       signal-exit: 4.1.0
-    optional: true
 
-  fp-ts@2.16.9:
-    optional: true
+  fp-ts@2.16.9: {}
 
-  fromentries@1.3.2:
-    optional: true
+  fromentries@1.3.2: {}
 
   fs-extra@11.1.1:
     dependencies:
@@ -5294,14 +5072,12 @@ snapshots:
       jsonfile: 6.1.0
       universalify: 2.0.1
 
-  fs.realpath@1.0.0:
-    optional: true
+  fs.realpath@1.0.0: {}
 
   fsevents@2.3.3:
     optional: true
 
-  function-bind@1.1.2:
-    optional: true
+  function-bind@1.1.2: {}
 
   function.prototype.name@1.1.6:
     dependencies:
@@ -5309,13 +5085,10 @@ snapshots:
       define-properties: 1.2.1
       es-abstract: 1.23.3
       functions-have-names: 1.2.3
-    optional: true
 
-  functions-have-names@1.2.3:
-    optional: true
+  functions-have-names@1.2.3: {}
 
-  get-caller-file@2.0.5:
-    optional: true
+  get-caller-file@2.0.5: {}
 
   get-intrinsic@1.2.4:
     dependencies:
@@ -5324,13 +5097,11 @@ snapshots:
       has-proto: 1.0.3
       has-symbols: 1.0.3
       hasown: 2.0.2
-    optional: true
 
   get-monorepo-packages@1.2.0:
     dependencies:
       globby: 7.1.1
       load-json-file: 4.0.0
-    optional: true
 
   get-pkg-repo@4.2.1:
     dependencies:
@@ -5338,17 +5109,14 @@ snapshots:
       hosted-git-info: 4.1.0
       through2: 2.0.5
       yargs: 16.2.0
-    optional: true
 
-  get-stream@6.0.1:
-    optional: true
+  get-stream@6.0.1: {}
 
   get-symbol-description@1.0.2:
     dependencies:
       call-bind: 1.0.7
       es-errors: 1.3.0
       get-intrinsic: 1.2.4
-    optional: true
 
   git-raw-commits@2.0.11:
     dependencies:
@@ -5357,24 +5125,20 @@ snapshots:
       meow: 8.1.2
       split2: 3.2.2
       through2: 4.0.2
-    optional: true
 
   git-remote-origin-url@2.0.0:
     dependencies:
       gitconfiglocal: 1.0.0
       pify: 2.3.0
-    optional: true
 
   git-semver-tags@4.1.1:
     dependencies:
       meow: 8.1.2
       semver: 6.3.1
-    optional: true
 
   gitconfiglocal@1.0.0:
     dependencies:
       ini: 1.3.8
-    optional: true
 
   gitlog@4.0.8:
     dependencies:
@@ -5382,12 +5146,10 @@ snapshots:
       tslib: 2.8.0
     transitivePeerDependencies:
       - supports-color
-    optional: true
 
   glob-parent@5.1.2:
     dependencies:
       is-glob: 4.0.3
-    optional: true
 
   glob@10.4.5:
     dependencies:
@@ -5397,7 +5159,6 @@ snapshots:
       minipass: 7.1.2
       package-json-from-dist: 1.0.1
       path-scurry: 1.11.1
-    optional: true
 
   glob@7.2.3:
     dependencies:
@@ -5407,13 +5168,11 @@ snapshots:
       minimatch: 3.1.2
       once: 1.4.0
       path-is-absolute: 1.0.1
-    optional: true
 
   globalthis@1.0.4:
     dependencies:
       define-properties: 1.2.1
       gopd: 1.0.1
-    optional: true
 
   globalyzer@0.1.0: {}
 
@@ -5425,7 +5184,6 @@ snapshots:
       path-type: 5.0.0
       slash: 5.1.0
       unicorn-magic: 0.1.0
-    optional: true
 
   globby@7.1.1:
     dependencies:
@@ -5435,14 +5193,12 @@ snapshots:
       ignore: 3.3.10
       pify: 3.0.0
       slash: 1.0.0
-    optional: true
 
   globrex@0.1.2: {}
 
   gopd@1.0.1:
     dependencies:
       get-intrinsic: 1.2.4
-    optional: true
 
   graceful-fs@4.2.11: {}
 
@@ -5455,38 +5211,29 @@ snapshots:
     optionalDependencies:
       uglify-js: 3.19.3
 
-  hard-rejection@2.1.0:
-    optional: true
+  hard-rejection@2.1.0: {}
 
-  has-bigints@1.0.2:
-    optional: true
+  has-bigints@1.0.2: {}
 
-  has-flag@3.0.0:
-    optional: true
+  has-flag@3.0.0: {}
 
-  has-flag@4.0.0:
-    optional: true
+  has-flag@4.0.0: {}
 
   has-property-descriptors@1.0.2:
     dependencies:
       es-define-property: 1.0.0
-    optional: true
 
-  has-proto@1.0.3:
-    optional: true
+  has-proto@1.0.3: {}
 
-  has-symbols@1.0.3:
-    optional: true
+  has-symbols@1.0.3: {}
 
   has-tostringtag@1.0.2:
     dependencies:
       has-symbols: 1.0.3
-    optional: true
 
   hasown@2.0.2:
     dependencies:
       function-bind: 1.1.2
-    optional: true
 
   hast-util-to-html@9.0.3:
     dependencies:
@@ -5501,28 +5248,22 @@ snapshots:
       space-separated-tokens: 2.0.2
       stringify-entities: 4.0.4
       zwitch: 2.0.4
-    optional: true
 
   hast-util-whitespace@3.0.0:
     dependencies:
       '@types/hast': 3.0.4
-    optional: true
 
   help-me@5.0.0: {}
 
-  hosted-git-info@2.8.9:
-    optional: true
+  hosted-git-info@2.8.9: {}
 
   hosted-git-info@4.1.0:
     dependencies:
       lru-cache: 6.0.0
-    optional: true
 
-  html-escaper@2.0.2:
-    optional: true
+  html-escaper@2.0.2: {}
 
-  html-void-elements@3.0.0:
-    optional: true
+  html-void-elements@3.0.0: {}
 
   https-proxy-agent@5.0.1:
     dependencies:
@@ -5530,54 +5271,42 @@ snapshots:
       debug: 4.3.7
     transitivePeerDependencies:
       - supports-color
-    optional: true
 
-  human-signals@2.1.0:
-    optional: true
+  human-signals@2.1.0: {}
 
   iconv-lite@0.4.24:
     dependencies:
       safer-buffer: 2.1.2
-    optional: true
 
   ieee754@1.2.1: {}
 
-  ignore@3.3.10:
-    optional: true
+  ignore@3.3.10: {}
 
-  ignore@5.3.2:
-    optional: true
+  ignore@5.3.2: {}
 
   import-cwd@3.0.0:
     dependencies:
       import-from: 3.0.0
-    optional: true
 
   import-fresh@3.3.0:
     dependencies:
       parent-module: 1.0.1
       resolve-from: 4.0.0
-    optional: true
 
   import-from@3.0.0:
     dependencies:
       resolve-from: 5.0.0
-    optional: true
 
-  indent-string@4.0.0:
-    optional: true
+  indent-string@4.0.0: {}
 
   inflight@1.0.6:
     dependencies:
       once: 1.4.0
       wrappy: 1.0.2
-    optional: true
 
-  inherits@2.0.4:
-    optional: true
+  inherits@2.0.4: {}
 
-  ini@1.3.8:
-    optional: true
+  ini@1.3.8: {}
 
   inquirer@7.3.3:
     dependencies:
@@ -5594,91 +5323,70 @@ snapshots:
       string-width: 4.2.3
       strip-ansi: 6.0.1
       through: 2.3.8
-    optional: true
 
   internal-slot@1.0.7:
     dependencies:
       es-errors: 1.3.0
       hasown: 2.0.2
       side-channel: 1.0.6
-    optional: true
 
   io-ts@2.2.21(fp-ts@2.16.9):
     dependencies:
       fp-ts: 2.16.9
-    optional: true
 
   is-array-buffer@3.0.4:
     dependencies:
       call-bind: 1.0.7
       get-intrinsic: 1.2.4
-    optional: true
 
-  is-arrayish@0.2.1:
-    optional: true
+  is-arrayish@0.2.1: {}
 
   is-bigint@1.0.4:
     dependencies:
       has-bigints: 1.0.2
-    optional: true
 
   is-boolean-object@1.1.2:
     dependencies:
       call-bind: 1.0.7
       has-tostringtag: 1.0.2
-    optional: true
 
-  is-callable@1.2.7:
-    optional: true
+  is-callable@1.2.7: {}
 
   is-core-module@2.15.1:
     dependencies:
       hasown: 2.0.2
-    optional: true
 
   is-data-view@1.0.1:
     dependencies:
       is-typed-array: 1.1.13
-    optional: true
 
   is-date-object@1.0.5:
     dependencies:
       has-tostringtag: 1.0.2
-    optional: true
 
-  is-docker@2.2.1:
-    optional: true
+  is-docker@2.2.1: {}
 
-  is-extglob@2.1.1:
-    optional: true
+  is-extglob@2.1.1: {}
 
-  is-fullwidth-code-point@3.0.0:
-    optional: true
+  is-fullwidth-code-point@3.0.0: {}
 
   is-glob@4.0.3:
     dependencies:
       is-extglob: 2.1.1
-    optional: true
 
-  is-negative-zero@2.0.3:
-    optional: true
+  is-negative-zero@2.0.3: {}
 
   is-number-object@1.0.7:
     dependencies:
       has-tostringtag: 1.0.2
-    optional: true
 
-  is-number@7.0.0:
-    optional: true
+  is-number@7.0.0: {}
 
-  is-plain-obj@1.1.0:
-    optional: true
+  is-plain-obj@1.1.0: {}
 
-  is-plain-object@5.0.0:
-    optional: true
+  is-plain-object@5.0.0: {}
 
-  is-port-reachable@4.0.0:
-    optional: true
+  is-port-reachable@4.0.0: {}
 
   is-reference@3.0.2:
     dependencies:
@@ -5688,67 +5396,52 @@ snapshots:
     dependencies:
       call-bind: 1.0.7
       has-tostringtag: 1.0.2
-    optional: true
 
   is-shared-array-buffer@1.0.3:
     dependencies:
       call-bind: 1.0.7
-    optional: true
 
-  is-stream@2.0.1:
-    optional: true
+  is-stream@2.0.1: {}
 
   is-string@1.0.7:
     dependencies:
       has-tostringtag: 1.0.2
-    optional: true
 
   is-symbol@1.0.4:
     dependencies:
       has-symbols: 1.0.3
-    optional: true
 
   is-text-path@1.0.1:
     dependencies:
       text-extensions: 1.9.0
-    optional: true
 
   is-typed-array@1.1.13:
     dependencies:
       which-typed-array: 1.1.15
-    optional: true
 
-  is-unicode-supported@0.1.0:
-    optional: true
+  is-unicode-supported@0.1.0: {}
 
   is-weakref@1.0.2:
     dependencies:
       call-bind: 1.0.7
-    optional: true
 
   is-wsl@2.2.0:
     dependencies:
       is-docker: 2.2.1
-    optional: true
 
-  isarray@1.0.0:
-    optional: true
+  isarray@1.0.0: {}
 
-  isarray@2.0.5:
-    optional: true
+  isarray@2.0.5: {}
 
-  isexe@2.0.0:
-    optional: true
+  isexe@2.0.0: {}
 
-  istanbul-lib-coverage@3.2.2:
-    optional: true
+  istanbul-lib-coverage@3.2.2: {}
 
   istanbul-lib-report@3.0.1:
     dependencies:
       istanbul-lib-coverage: 3.2.2
       make-dir: 4.0.0
       supports-color: 7.2.0
-    optional: true
 
   istanbul-lib-source-maps@5.0.6:
     dependencies:
@@ -5757,55 +5450,43 @@ snapshots:
       istanbul-lib-coverage: 3.2.2
     transitivePeerDependencies:
       - supports-color
-    optional: true
 
   istanbul-reports@3.1.7:
     dependencies:
       html-escaper: 2.0.2
       istanbul-lib-report: 3.0.1
-    optional: true
 
   jackspeak@3.4.3:
     dependencies:
       '@isaacs/cliui': 8.0.2
     optionalDependencies:
       '@pkgjs/parseargs': 0.11.0
-    optional: true
 
-  java-properties@1.0.2:
-    optional: true
+  java-properties@1.0.2: {}
 
   joycon@3.1.1: {}
 
-  js-tokens@4.0.0:
-    optional: true
+  js-tokens@4.0.0: {}
 
   js-yaml@4.1.0:
     dependencies:
       argparse: 2.0.1
-    optional: true
 
   json-fixer@1.6.15:
     dependencies:
       '@babel/runtime': 7.24.7
       chalk: 4.1.2
       pegjs: 0.10.0
-    optional: true
 
-  json-parse-better-errors@1.0.2:
-    optional: true
+  json-parse-better-errors@1.0.2: {}
 
-  json-parse-even-better-errors@2.3.1:
-    optional: true
+  json-parse-even-better-errors@2.3.1: {}
 
-  json-schema-traverse@1.0.0:
-    optional: true
+  json-schema-traverse@1.0.0: {}
 
-  json-stringify-safe@5.0.1:
-    optional: true
+  json-stringify-safe@5.0.1: {}
 
-  jsonc-parser@3.3.1:
-    optional: true
+  jsonc-parser@3.3.1: {}
 
   jsonfile@6.1.0:
     dependencies:
@@ -5813,21 +5494,17 @@ snapshots:
     optionalDependencies:
       graceful-fs: 4.2.11
 
-  jsonparse@1.3.1:
-    optional: true
+  jsonparse@1.3.1: {}
 
-  kind-of@6.0.3:
-    optional: true
+  kind-of@6.0.3: {}
 
   kleur@4.1.5: {}
 
-  lines-and-columns@1.2.4:
-    optional: true
+  lines-and-columns@1.2.4: {}
 
   linkify-it@5.0.0:
     dependencies:
       uc.micro: 2.1.0
-    optional: true
 
   load-json-file@4.0.0:
     dependencies:
@@ -5835,7 +5512,6 @@ snapshots:
       parse-json: 4.0.0
       pify: 3.0.0
       strip-bom: 3.0.0
-    optional: true
 
   locate-character@3.0.0: {}
 
@@ -5843,51 +5519,39 @@ snapshots:
     dependencies:
       p-locate: 2.0.0
       path-exists: 3.0.0
-    optional: true
 
   locate-path@5.0.0:
     dependencies:
       p-locate: 4.1.0
-    optional: true
 
   locate-path@7.2.0:
     dependencies:
       p-locate: 6.0.0
 
-  lodash.camelcase@4.3.0:
-    optional: true
+  lodash.camelcase@4.3.0: {}
 
-  lodash.chunk@4.2.0:
-    optional: true
+  lodash.chunk@4.2.0: {}
 
-  lodash.get@4.4.2:
-    optional: true
+  lodash.get@4.4.2: {}
 
-  lodash.ismatch@4.4.0:
-    optional: true
+  lodash.ismatch@4.4.0: {}
 
-  lodash@4.17.21:
-    optional: true
+  lodash@4.17.21: {}
 
   log-symbols@4.1.0:
     dependencies:
       chalk: 4.1.2
       is-unicode-supported: 0.1.0
-    optional: true
 
-  loupe@3.1.2:
-    optional: true
+  loupe@3.1.2: {}
 
-  lru-cache@10.4.3:
-    optional: true
+  lru-cache@10.4.3: {}
 
   lru-cache@6.0.0:
     dependencies:
       yallist: 4.0.0
-    optional: true
 
-  lunr@2.3.9:
-    optional: true
+  lunr@2.3.9: {}
 
   magic-string@0.30.10:
     dependencies:
@@ -5900,28 +5564,22 @@ snapshots:
   magic-string@0.30.12:
     dependencies:
       '@jridgewell/sourcemap-codec': 1.5.0
-    optional: true
 
   magicast@0.3.5:
     dependencies:
       '@babel/parser': 7.26.1
       '@babel/types': 7.26.0
       source-map-js: 1.2.1
-    optional: true
 
   make-dir@4.0.0:
     dependencies:
       semver: 7.6.3
-    optional: true
 
-  make-error@1.3.6:
-    optional: true
+  make-error@1.3.6: {}
 
-  map-obj@1.0.1:
-    optional: true
+  map-obj@1.0.1: {}
 
-  map-obj@4.3.0:
-    optional: true
+  map-obj@4.3.0: {}
 
   map-or-similar@1.5.0: {}
 
@@ -5933,12 +5591,10 @@ snapshots:
       mdurl: 2.0.0
       punycode.js: 2.3.1
       uc.micro: 2.1.0
-    optional: true
 
   markdownlint-cli2-formatter-default@0.0.5(markdownlint-cli2@0.14.0):
     dependencies:
       markdownlint-cli2: 0.14.0
-    optional: true
 
   markdownlint-cli2@0.14.0:
     dependencies:
@@ -5948,16 +5604,13 @@ snapshots:
       markdownlint: 0.35.0
       markdownlint-cli2-formatter-default: 0.0.5(markdownlint-cli2@0.14.0)
       micromatch: 4.0.8
-    optional: true
 
-  markdownlint-micromark@0.1.10:
-    optional: true
+  markdownlint-micromark@0.1.10: {}
 
   markdownlint@0.35.0:
     dependencies:
       markdown-it: 14.1.0
       markdownlint-micromark: 0.1.10
-    optional: true
 
   mdast-util-to-hast@13.2.0:
     dependencies:
@@ -5970,13 +5623,10 @@ snapshots:
       unist-util-position: 5.0.0
       unist-util-visit: 5.0.0
       vfile: 6.0.3
-    optional: true
 
-  mdurl@2.0.0:
-    optional: true
+  mdurl@2.0.0: {}
 
-  meant@1.0.3:
-    optional: true
+  meant@1.0.3: {}
 
   memoizerific@1.11.3:
     dependencies:
@@ -5995,129 +5645,98 @@ snapshots:
       trim-newlines: 3.0.1
       type-fest: 0.18.1
       yargs-parser: 20.2.9
-    optional: true
 
-  merge-stream@2.0.0:
-    optional: true
+  merge-stream@2.0.0: {}
 
-  merge2@1.4.1:
-    optional: true
+  merge2@1.4.1: {}
 
   micromark-util-character@2.1.0:
     dependencies:
       micromark-util-symbol: 2.0.0
       micromark-util-types: 2.0.0
-    optional: true
 
-  micromark-util-encode@2.0.0:
-    optional: true
+  micromark-util-encode@2.0.0: {}
 
   micromark-util-sanitize-uri@2.0.0:
     dependencies:
       micromark-util-character: 2.1.0
       micromark-util-encode: 2.0.0
       micromark-util-symbol: 2.0.0
-    optional: true
 
-  micromark-util-symbol@2.0.0:
-    optional: true
+  micromark-util-symbol@2.0.0: {}
 
-  micromark-util-types@2.0.0:
-    optional: true
+  micromark-util-types@2.0.0: {}
 
   micromatch@4.0.8:
     dependencies:
       braces: 3.0.3
       picomatch: 2.3.1
-    optional: true
 
-  mime-db@1.33.0:
-    optional: true
+  mime-db@1.33.0: {}
 
-  mime-db@1.52.0:
-    optional: true
+  mime-db@1.52.0: {}
 
-  mime-db@1.53.0:
-    optional: true
+  mime-db@1.53.0: {}
 
   mime-types@2.1.18:
     dependencies:
       mime-db: 1.33.0
-    optional: true
 
   mime-types@2.1.35:
     dependencies:
       mime-db: 1.52.0
-    optional: true
 
-  mimic-fn@2.1.0:
-    optional: true
+  mimic-fn@2.1.0: {}
 
-  min-indent@1.0.1:
-    optional: true
+  min-indent@1.0.1: {}
 
   minimatch@3.1.2:
     dependencies:
       brace-expansion: 1.1.11
-    optional: true
 
   minimatch@9.0.5:
     dependencies:
       brace-expansion: 2.0.1
-    optional: true
 
   minimist-options@4.1.0:
     dependencies:
       arrify: 1.0.1
       is-plain-obj: 1.1.0
       kind-of: 6.0.3
-    optional: true
 
   minimist@1.2.8: {}
 
-  minipass@7.1.2:
-    optional: true
+  minipass@7.1.2: {}
 
-  modify-values@1.0.1:
-    optional: true
+  modify-values@1.0.1: {}
 
-  module-alias@2.2.3:
-    optional: true
+  module-alias@2.2.3: {}
 
   mri@1.2.0: {}
 
-  mrmime@2.0.0:
-    optional: true
+  mrmime@2.0.0: {}
 
-  ms@2.0.0:
-    optional: true
+  ms@2.0.0: {}
 
-  ms@2.1.3:
-    optional: true
+  ms@2.1.3: {}
 
-  mute-stream@0.0.8:
-    optional: true
+  mute-stream@0.0.8: {}
 
-  nanoid@3.3.7:
-    optional: true
+  nanoid@3.3.7: {}
 
-  negotiator@0.6.3:
-    optional: true
+  negotiator@0.6.3: {}
 
   neo-async@2.6.2: {}
 
-  nested-error-stacks@2.0.1:
-    optional: true
+  nested-error-stacks@2.0.1: {}
 
   node-fetch@2.6.7:
     dependencies:
       whatwg-url: 5.0.0
-    optional: true
 
   node-fetch@2.7.0:
     dependencies:
       whatwg-url: 5.0.0
-    optional: true
 
   normalize-package-data@2.5.0:
     dependencies:
@@ -6125,7 +5744,6 @@ snapshots:
       resolve: 1.22.8
       semver: 5.7.2
       validate-npm-package-license: 3.0.4
-    optional: true
 
   normalize-package-data@3.0.3:
     dependencies:
@@ -6133,21 +5751,16 @@ snapshots:
       is-core-module: 2.15.1
       semver: 7.6.3
       validate-npm-package-license: 3.0.4
-    optional: true
 
-  normalize-path@3.0.0:
-    optional: true
+  normalize-path@3.0.0: {}
 
   npm-run-path@4.0.1:
     dependencies:
       path-key: 3.1.1
-    optional: true
 
-  object-inspect@1.13.2:
-    optional: true
+  object-inspect@1.13.2: {}
 
-  object-keys@1.1.1:
-    optional: true
+  object-keys@1.1.1: {}
 
   object.assign@4.1.5:
     dependencies:
@@ -6155,15 +5768,12 @@ snapshots:
       define-properties: 1.2.1
       has-symbols: 1.0.3
       object-keys: 1.1.1
-    optional: true
 
-  objectorarray@1.0.5:
-    optional: true
+  objectorarray@1.0.5: {}
 
   on-exit-leak-free@2.1.2: {}
 
-  on-headers@1.0.2:
-    optional: true
+  on-headers@1.0.2: {}
 
   once@1.4.0:
     dependencies:
@@ -6172,28 +5782,22 @@ snapshots:
   onetime@5.1.2:
     dependencies:
       mimic-fn: 2.1.0
-    optional: true
 
   oniguruma-to-js@0.4.3:
     dependencies:
       regex: 4.3.3
-    optional: true
 
-  os-homedir@1.0.2:
-    optional: true
+  os-homedir@1.0.2: {}
 
-  os-tmpdir@1.0.2:
-    optional: true
+  os-tmpdir@1.0.2: {}
 
   p-limit@1.3.0:
     dependencies:
       p-try: 1.0.0
-    optional: true
 
   p-limit@2.3.0:
     dependencies:
       p-try: 2.2.0
-    optional: true
 
   p-limit@4.0.0:
     dependencies:
@@ -6202,44 +5806,35 @@ snapshots:
   p-locate@2.0.0:
     dependencies:
       p-limit: 1.3.0
-    optional: true
 
   p-locate@4.1.0:
     dependencies:
       p-limit: 2.3.0
-    optional: true
 
   p-locate@6.0.0:
     dependencies:
       p-limit: 4.0.0
 
-  p-try@1.0.0:
-    optional: true
+  p-try@1.0.0: {}
 
-  p-try@2.2.0:
-    optional: true
+  p-try@2.2.0: {}
 
-  package-json-from-dist@1.0.1:
-    optional: true
+  package-json-from-dist@1.0.1: {}
 
   parent-module@1.0.1:
     dependencies:
       callsites: 3.1.0
-    optional: true
 
   parse-author@2.0.0:
     dependencies:
       author-regex: 1.0.0
-    optional: true
 
-  parse-github-url@1.0.2:
-    optional: true
+  parse-github-url@1.0.2: {}
 
   parse-json@4.0.0:
     dependencies:
       error-ex: 1.3.2
       json-parse-better-errors: 1.0.2
-    optional: true
 
   parse-json@5.2.0:
     dependencies:
@@ -6247,76 +5842,55 @@ snapshots:
       error-ex: 1.3.2
       json-parse-even-better-errors: 2.3.1
       lines-and-columns: 1.2.4
-    optional: true
 
-  parse-ms@2.1.0:
-    optional: true
+  parse-ms@2.1.0: {}
 
-  path-exists@3.0.0:
-    optional: true
+  path-exists@3.0.0: {}
 
-  path-exists@4.0.0:
-    optional: true
+  path-exists@4.0.0: {}
 
   path-exists@5.0.0: {}
 
-  path-is-absolute@1.0.1:
-    optional: true
+  path-is-absolute@1.0.1: {}
 
-  path-is-inside@1.0.2:
-    optional: true
+  path-is-inside@1.0.2: {}
 
-  path-key@3.1.1:
-    optional: true
+  path-key@3.1.1: {}
 
-  path-parse@1.0.7:
-    optional: true
+  path-parse@1.0.7: {}
 
   path-scurry@1.11.1:
     dependencies:
       lru-cache: 10.4.3
       minipass: 7.1.2
-    optional: true
 
-  path-to-regexp@3.3.0:
-    optional: true
+  path-to-regexp@3.3.0: {}
 
   path-type@3.0.0:
     dependencies:
       pify: 3.0.0
-    optional: true
 
-  path-type@4.0.0:
-    optional: true
+  path-type@4.0.0: {}
 
-  path-type@5.0.0:
-    optional: true
+  path-type@5.0.0: {}
 
-  pathe@1.1.2:
-    optional: true
+  pathe@1.1.2: {}
 
-  pathval@2.0.0:
-    optional: true
+  pathval@2.0.0: {}
 
-  pegjs@0.10.0:
-    optional: true
+  pegjs@0.10.0: {}
 
-  picocolors@1.1.1:
-    optional: true
+  picocolors@1.1.1: {}
 
   picomatch@2.3.1: {}
 
-  picomatch@4.0.2:
-    optional: true
+  picomatch@4.0.2: {}
 
-  pify@2.3.0:
-    optional: true
+  pify@2.3.0: {}
 
-  pify@3.0.0:
-    optional: true
+  pify@3.0.0: {}
 
-  pify@5.0.0:
-    optional: true
+  pify@5.0.0: {}
 
   pino-abstract-transport@1.1.0:
     dependencies:
@@ -6365,17 +5939,14 @@ snapshots:
     dependencies:
       find-up: 2.1.0
       load-json-file: 4.0.0
-    optional: true
 
-  possible-typed-array-names@1.0.0:
-    optional: true
+  possible-typed-array-names@1.0.0: {}
 
   postcss@8.4.47:
     dependencies:
       nanoid: 3.3.7
       picocolors: 1.1.1
       source-map-js: 1.2.1
-    optional: true
 
   prettier@2.8.8:
     optional: true
@@ -6383,44 +5954,35 @@ snapshots:
   pretty-ms@7.0.1:
     dependencies:
       parse-ms: 2.1.0
-    optional: true
 
-  process-nextick-args@2.0.1:
-    optional: true
+  process-nextick-args@2.0.1: {}
 
   process-warning@3.0.0: {}
 
   process@0.11.10: {}
 
-  property-information@6.5.0:
-    optional: true
+  property-information@6.5.0: {}
 
   pump@3.0.0:
     dependencies:
       end-of-stream: 1.4.4
       once: 1.4.0
 
-  punycode.js@2.3.1:
-    optional: true
+  punycode.js@2.3.1: {}
 
-  punycode@2.3.1:
-    optional: true
+  punycode@2.3.1: {}
 
-  q@1.5.1:
-    optional: true
+  q@1.5.1: {}
 
-  queue-microtask@1.2.3:
-    optional: true
+  queue-microtask@1.2.3: {}
 
   quick-format-unescaped@4.0.4: {}
 
-  quick-lru@4.0.1:
-    optional: true
+  quick-lru@4.0.1: {}
 
   ramda@0.29.0: {}
 
-  range-parser@1.2.0:
-    optional: true
+  range-parser@1.2.0: {}
 
   rc@1.2.8:
     dependencies:
@@ -6428,27 +5990,23 @@ snapshots:
       ini: 1.3.8
       minimist: 1.2.8
       strip-json-comments: 2.0.1
-    optional: true
 
   read-pkg-up@3.0.0:
     dependencies:
       find-up: 2.1.0
       read-pkg: 3.0.0
-    optional: true
 
   read-pkg-up@7.0.1:
     dependencies:
       find-up: 4.1.0
       read-pkg: 5.2.0
       type-fest: 0.8.1
-    optional: true
 
   read-pkg@3.0.0:
     dependencies:
       load-json-file: 4.0.0
       normalize-package-data: 2.5.0
       path-type: 3.0.0
-    optional: true
 
   read-pkg@5.2.0:
     dependencies:
@@ -6456,7 +6014,6 @@ snapshots:
       normalize-package-data: 2.5.0
       parse-json: 5.2.0
       type-fest: 0.6.0
-    optional: true
 
   readable-stream@2.3.8:
     dependencies:
@@ -6467,14 +6024,12 @@ snapshots:
       safe-buffer: 5.1.2
       string_decoder: 1.1.1
       util-deprecate: 1.0.2
-    optional: true
 
   readable-stream@3.6.2:
     dependencies:
       inherits: 2.0.4
       string_decoder: 1.3.0
       util-deprecate: 1.0.2
-    optional: true
 
   readable-stream@4.5.2:
     dependencies:
@@ -6490,16 +6045,12 @@ snapshots:
     dependencies:
       indent-string: 4.0.0
       strip-indent: 3.0.0
-    optional: true
 
-  reduce-flatten@2.0.0:
-    optional: true
+  reduce-flatten@2.0.0: {}
 
-  regenerator-runtime@0.14.1:
-    optional: true
+  regenerator-runtime@0.14.1: {}
 
-  regex@4.3.3:
-    optional: true
+  regex@4.3.3: {}
 
   regexp.prototype.flags@1.5.3:
     dependencies:
@@ -6507,48 +6058,37 @@ snapshots:
       define-properties: 1.2.1
       es-errors: 1.3.0
       set-function-name: 2.0.2
-    optional: true
 
   registry-auth-token@3.3.2:
     dependencies:
       rc: 1.2.8
       safe-buffer: 5.2.1
-    optional: true
 
   registry-url@3.1.0:
     dependencies:
       rc: 1.2.8
-    optional: true
 
   registry-url@5.1.0:
     dependencies:
       rc: 1.2.8
-    optional: true
 
-  remove-markdown@0.3.0:
-    optional: true
+  remove-markdown@0.3.0: {}
 
-  require-directory@2.1.1:
-    optional: true
+  require-directory@2.1.1: {}
 
-  require-from-string@2.0.2:
-    optional: true
+  require-from-string@2.0.2: {}
 
-  require-main-filename@2.0.0:
-    optional: true
+  require-main-filename@2.0.0: {}
 
   requireg@0.2.2:
     dependencies:
       nested-error-stacks: 2.0.1
       rc: 1.2.8
       resolve: 1.7.1
-    optional: true
 
-  resolve-from@4.0.0:
-    optional: true
+  resolve-from@4.0.0: {}
 
-  resolve-from@5.0.0:
-    optional: true
+  resolve-from@5.0.0: {}
 
   resolve.exports@2.0.2: {}
 
@@ -6557,21 +6097,17 @@ snapshots:
       is-core-module: 2.15.1
       path-parse: 1.0.7
       supports-preserve-symlinks-flag: 1.0.0
-    optional: true
 
   resolve@1.7.1:
     dependencies:
       path-parse: 1.0.7
-    optional: true
 
   restore-cursor@3.1.0:
     dependencies:
       onetime: 5.1.2
       signal-exit: 3.0.7
-    optional: true
 
-  reusify@1.0.4:
-    optional: true
+  reusify@1.0.4: {}
 
   rollup-plugin-svelte@7.2.2(rollup@4.18.0)(svelte@5.0.0-next.164):
     dependencies:
@@ -6625,20 +6161,16 @@ snapshots:
       '@rollup/rollup-win32-ia32-msvc': 4.24.3
       '@rollup/rollup-win32-x64-msvc': 4.24.3
       fsevents: 2.3.3
-    optional: true
 
-  run-async@2.4.1:
-    optional: true
+  run-async@2.4.1: {}
 
   run-parallel@1.2.0:
     dependencies:
       queue-microtask: 1.2.3
-    optional: true
 
   rxjs@6.6.7:
     dependencies:
       tslib: 1.10.0
-    optional: true
 
   sade@1.8.1:
     dependencies:
@@ -6650,10 +6182,8 @@ snapshots:
       get-intrinsic: 1.2.4
       has-symbols: 1.0.3
       isarray: 2.0.5
-    optional: true
 
-  safe-buffer@5.1.2:
-    optional: true
+  safe-buffer@5.1.2: {}
 
   safe-buffer@5.2.1: {}
 
@@ -6662,23 +6192,18 @@ snapshots:
       call-bind: 1.0.7
       es-errors: 1.3.0
       is-regex: 1.1.4
-    optional: true
 
   safe-stable-stringify@2.4.3: {}
 
-  safer-buffer@2.1.2:
-    optional: true
+  safer-buffer@2.1.2: {}
 
   secure-json-parse@2.7.0: {}
 
-  semver@5.7.2:
-    optional: true
+  semver@5.7.2: {}
 
-  semver@6.3.1:
-    optional: true
+  semver@6.3.1: {}
 
-  semver@7.6.3:
-    optional: true
+  semver@7.6.3: {}
 
   serve-handler@6.1.6:
     dependencies:
@@ -6689,7 +6214,6 @@ snapshots:
       path-is-inside: 1.0.2
       path-to-regexp: 3.3.0
       range-parser: 1.2.0
-    optional: true
 
   serve@14.2.4:
     dependencies:
@@ -6706,10 +6230,8 @@ snapshots:
       update-check: 1.5.4
     transitivePeerDependencies:
       - supports-color
-    optional: true
 
-  set-blocking@2.0.0:
-    optional: true
+  set-blocking@2.0.0: {}
 
   set-function-length@1.2.2:
     dependencies:
@@ -6719,7 +6241,6 @@ snapshots:
       get-intrinsic: 1.2.4
       gopd: 1.0.1
       has-property-descriptors: 1.0.2
-    optional: true
 
   set-function-name@2.0.2:
     dependencies:
@@ -6727,15 +6248,12 @@ snapshots:
       es-errors: 1.3.0
       functions-have-names: 1.2.3
       has-property-descriptors: 1.0.2
-    optional: true
 
   shebang-command@2.0.0:
     dependencies:
       shebang-regex: 3.0.0
-    optional: true
 
-  shebang-regex@3.0.0:
-    optional: true
+  shebang-regex@3.0.0: {}
 
   shiki@1.22.2:
     dependencies:
@@ -6745,7 +6263,6 @@ snapshots:
       '@shikijs/types': 1.22.2
       '@shikijs/vscode-textmate': 9.3.0
       '@types/hast': 3.0.4
-    optional: true
 
   side-channel@1.0.6:
     dependencies:
@@ -6753,104 +6270,83 @@ snapshots:
       es-errors: 1.3.0
       get-intrinsic: 1.2.4
       object-inspect: 1.13.2
-    optional: true
 
-  siginfo@2.0.0:
-    optional: true
+  siginfo@2.0.0: {}
 
-  signal-exit@3.0.7:
-    optional: true
+  signal-exit@3.0.7: {}
 
-  signal-exit@4.1.0:
-    optional: true
+  signal-exit@4.1.0: {}
 
   signale@1.4.0:
     dependencies:
       chalk: 2.4.2
       figures: 2.0.0
       pkg-conf: 2.1.0
-    optional: true
 
   sirv@3.0.0:
     dependencies:
       '@polka/url': 1.0.0-next.28
       mrmime: 2.0.0
       totalist: 3.0.1
-    optional: true
 
-  slash@1.0.0:
-    optional: true
+  slash@1.0.0: {}
 
-  slash@5.1.0:
-    optional: true
+  slash@5.1.0: {}
 
   sonic-boom@3.8.1:
     dependencies:
       atomic-sleep: 1.0.0
 
-  source-map-js@1.2.1:
-    optional: true
+  source-map-js@1.2.1: {}
 
   source-map-support@0.5.21:
     dependencies:
       buffer-from: 1.1.2
       source-map: 0.6.1
-    optional: true
 
   source-map@0.6.1: {}
 
-  space-separated-tokens@2.0.2:
-    optional: true
+  space-separated-tokens@2.0.2: {}
 
   spdx-correct@3.2.0:
     dependencies:
       spdx-expression-parse: 3.0.1
       spdx-license-ids: 3.0.20
-    optional: true
 
-  spdx-exceptions@2.5.0:
-    optional: true
+  spdx-exceptions@2.5.0: {}
 
   spdx-expression-parse@3.0.1:
     dependencies:
       spdx-exceptions: 2.5.0
       spdx-license-ids: 3.0.20
-    optional: true
 
-  spdx-license-ids@3.0.20:
-    optional: true
+  spdx-license-ids@3.0.20: {}
 
   split2@3.2.2:
     dependencies:
       readable-stream: 3.6.2
-    optional: true
 
   split2@4.2.0: {}
 
   split@1.0.1:
     dependencies:
       through: 2.3.8
-    optional: true
 
-  stackback@0.0.2:
-    optional: true
+  stackback@0.0.2: {}
 
-  std-env@3.7.0:
-    optional: true
+  std-env@3.7.0: {}
 
   string-width@4.2.3:
     dependencies:
       emoji-regex: 8.0.0
       is-fullwidth-code-point: 3.0.0
       strip-ansi: 6.0.1
-    optional: true
 
   string-width@5.1.2:
     dependencies:
       eastasianwidth: 0.2.0
       emoji-regex: 9.2.2
       strip-ansi: 7.1.0
-    optional: true
 
   string.prototype.trim@1.2.9:
     dependencies:
@@ -6858,26 +6354,22 @@ snapshots:
       define-properties: 1.2.1
       es-abstract: 1.23.3
       es-object-atoms: 1.0.0
-    optional: true
 
   string.prototype.trimend@1.0.8:
     dependencies:
       call-bind: 1.0.7
       define-properties: 1.2.1
       es-object-atoms: 1.0.0
-    optional: true
 
   string.prototype.trimstart@1.0.8:
     dependencies:
       call-bind: 1.0.7
       define-properties: 1.2.1
       es-object-atoms: 1.0.0
-    optional: true
 
   string_decoder@1.1.1:
     dependencies:
       safe-buffer: 5.1.2
-    optional: true
 
   string_decoder@1.3.0:
     dependencies:
@@ -6887,52 +6379,41 @@ snapshots:
     dependencies:
       character-entities-html4: 2.1.0
       character-entities-legacy: 3.0.0
-    optional: true
 
   strip-ansi@6.0.1:
     dependencies:
       ansi-regex: 5.0.1
-    optional: true
 
   strip-ansi@7.1.0:
     dependencies:
       ansi-regex: 6.1.0
-    optional: true
 
-  strip-bom@3.0.0:
-    optional: true
+  strip-bom@3.0.0: {}
 
-  strip-final-newline@2.0.0:
-    optional: true
+  strip-final-newline@2.0.0: {}
 
   strip-indent@3.0.0:
     dependencies:
       min-indent: 1.0.1
-    optional: true
 
-  strip-json-comments@2.0.1:
-    optional: true
+  strip-json-comments@2.0.1: {}
 
   strip-json-comments@3.1.1: {}
 
   supports-color@5.5.0:
     dependencies:
       has-flag: 3.0.0
-    optional: true
 
   supports-color@7.2.0:
     dependencies:
       has-flag: 4.0.0
-    optional: true
 
   supports-hyperlinks@2.3.0:
     dependencies:
       has-flag: 4.0.0
       supports-color: 7.2.0
-    optional: true
 
-  supports-preserve-symlinks-flag@1.0.0:
-    optional: true
+  supports-preserve-symlinks-flag@1.0.0: {}
 
   svelte@5.0.0-next.164:
     dependencies:
@@ -6972,10 +6453,8 @@ snapshots:
       deep-extend: 0.6.0
       typical: 5.2.0
       wordwrapjs: 4.0.1
-    optional: true
 
-  tapable@2.2.1:
-    optional: true
+  tapable@2.2.1: {}
 
   telejson@7.2.0:
     dependencies:
@@ -6985,17 +6464,14 @@ snapshots:
     dependencies:
       ansi-escapes: 4.3.2
       supports-hyperlinks: 2.3.0
-    optional: true
 
   test-exclude@7.0.1:
     dependencies:
       '@istanbuljs/schema': 0.1.3
       glob: 10.4.5
       minimatch: 9.0.5
-    optional: true
 
-  text-extensions@1.9.0:
-    optional: true
+  text-extensions@1.9.0: {}
 
   thread-stream@2.7.0:
     dependencies:
@@ -7005,15 +6481,12 @@ snapshots:
     dependencies:
       readable-stream: 2.3.8
       xtend: 4.0.2
-    optional: true
 
   through2@4.0.2:
     dependencies:
       readable-stream: 3.6.2
-    optional: true
 
-  through@2.3.8:
-    optional: true
+  through@2.3.8: {}
 
   tiny-glob@0.2.9:
     dependencies:
@@ -7022,51 +6495,38 @@ snapshots:
 
   tiny-invariant@1.3.3: {}
 
-  tinybench@2.9.0:
-    optional: true
+  tinybench@2.9.0: {}
 
-  tinycolor2@1.6.0:
-    optional: true
+  tinycolor2@1.6.0: {}
 
-  tinyexec@0.3.1:
-    optional: true
+  tinyexec@0.3.1: {}
 
   tinyglobby@0.2.10:
     dependencies:
       fdir: 6.4.2(picomatch@4.0.2)
       picomatch: 4.0.2
-    optional: true
 
-  tinypool@1.0.1:
-    optional: true
+  tinypool@1.0.1: {}
 
-  tinyrainbow@1.2.0:
-    optional: true
+  tinyrainbow@1.2.0: {}
 
-  tinyspy@3.0.2:
-    optional: true
+  tinyspy@3.0.2: {}
 
   tmp@0.0.33:
     dependencies:
       os-tmpdir: 1.0.2
-    optional: true
 
   to-regex-range@5.0.1:
     dependencies:
       is-number: 7.0.0
-    optional: true
 
-  totalist@3.0.1:
-    optional: true
+  totalist@3.0.1: {}
 
-  tr46@0.0.3:
-    optional: true
+  tr46@0.0.3: {}
 
-  trim-lines@3.0.1:
-    optional: true
+  trim-lines@3.0.1: {}
 
-  trim-newlines@3.0.1:
-    optional: true
+  trim-newlines@3.0.1: {}
 
   ts-api-utils@1.3.0(typescript@5.6.3):
     dependencies:
@@ -7091,7 +6551,6 @@ snapshots:
       typescript: 5.6.3
       v8-compile-cache-lib: 3.0.1
       yn: 3.1.1
-    optional: true
 
   ts-node@9.1.1(typescript@5.6.3):
     dependencies:
@@ -7102,28 +6561,20 @@ snapshots:
       source-map-support: 0.5.21
       typescript: 5.6.3
       yn: 3.1.1
-    optional: true
 
-  tslib@1.10.0:
-    optional: true
+  tslib@1.10.0: {}
 
-  tslib@2.1.0:
-    optional: true
+  tslib@2.1.0: {}
 
-  tslib@2.8.0:
-    optional: true
+  tslib@2.8.0: {}
 
-  type-fest@0.18.1:
-    optional: true
+  type-fest@0.18.1: {}
 
-  type-fest@0.21.3:
-    optional: true
+  type-fest@0.21.3: {}
 
-  type-fest@0.6.0:
-    optional: true
+  type-fest@0.6.0: {}
 
-  type-fest@0.8.1:
-    optional: true
+  type-fest@0.8.1: {}
 
   type-fest@2.19.0: {}
 
@@ -7136,7 +6587,6 @@ snapshots:
       call-bind: 1.0.7
       es-errors: 1.3.0
       is-typed-array: 1.1.13
-    optional: true
 
   typed-array-byte-length@1.0.1:
     dependencies:
@@ -7145,7 +6595,6 @@ snapshots:
       gopd: 1.0.1
       has-proto: 1.0.3
       is-typed-array: 1.1.13
-    optional: true
 
   typed-array-byte-offset@1.0.2:
     dependencies:
@@ -7155,7 +6604,6 @@ snapshots:
       gopd: 1.0.1
       has-proto: 1.0.3
       is-typed-array: 1.1.13
-    optional: true
 
   typed-array-length@1.0.6:
     dependencies:
@@ -7165,17 +6613,14 @@ snapshots:
       has-proto: 1.0.3
       is-typed-array: 1.1.13
       possible-typed-array-names: 1.0.0
-    optional: true
 
   typedoc-plugin-coverage@3.3.0(typedoc@0.26.10(typescript@5.6.3)):
     dependencies:
       typedoc: 0.26.10(typescript@5.6.3)
-    optional: true
 
   typedoc-plugin-mdn-links@3.3.5(typedoc@0.26.10(typescript@5.6.3)):
     dependencies:
       typedoc: 0.26.10(typescript@5.6.3)
-    optional: true
 
   typedoc@0.26.10(typescript@5.6.3):
     dependencies:
@@ -7185,23 +6630,18 @@ snapshots:
       shiki: 1.22.2
       typescript: 5.6.3
       yaml: 2.6.0
-    optional: true
 
-  typescript-memoize@1.1.1:
-    optional: true
+  typescript-memoize@1.1.1: {}
 
   typescript@5.5.2: {}
 
   typescript@5.6.3: {}
 
-  typical@4.0.0:
-    optional: true
+  typical@4.0.0: {}
 
-  typical@5.2.0:
-    optional: true
+  typical@5.2.0: {}
 
-  uc.micro@2.1.0:
-    optional: true
+  uc.micro@2.1.0: {}
 
   uglify-js@3.19.3:
     optional: true
@@ -7212,7 +6652,6 @@ snapshots:
       has-bigints: 1.0.2
       has-symbols: 1.0.3
       which-boxed-primitive: 1.0.2
-    optional: true
 
   undici-types@5.26.5: {}
 
@@ -7223,33 +6662,27 @@ snapshots:
   unist-util-is@6.0.0:
     dependencies:
       '@types/unist': 3.0.3
-    optional: true
 
   unist-util-position@5.0.0:
     dependencies:
       '@types/unist': 3.0.3
-    optional: true
 
   unist-util-stringify-position@4.0.0:
     dependencies:
       '@types/unist': 3.0.3
-    optional: true
 
   unist-util-visit-parents@6.0.1:
     dependencies:
       '@types/unist': 3.0.3
       unist-util-is: 6.0.0
-    optional: true
 
   unist-util-visit@5.0.0:
     dependencies:
       '@types/unist': 3.0.3
       unist-util-is: 6.0.0
       unist-util-visit-parents: 6.0.1
-    optional: true
 
-  universal-user-agent@6.0.1:
-    optional: true
+  universal-user-agent@6.0.1: {}
 
   universalify@2.0.1: {}
 
@@ -7257,26 +6690,20 @@ snapshots:
     dependencies:
       registry-auth-token: 3.3.2
       registry-url: 3.1.0
-    optional: true
 
   uri-js@4.4.1:
     dependencies:
       punycode: 2.3.1
-    optional: true
 
-  url-join@4.0.1:
-    optional: true
+  url-join@4.0.1: {}
 
   user-home@2.0.0:
     dependencies:
       os-homedir: 1.0.2
-    optional: true
 
-  util-deprecate@1.0.2:
-    optional: true
+  util-deprecate@1.0.2: {}
 
-  v8-compile-cache-lib@3.0.1:
-    optional: true
+  v8-compile-cache-lib@3.0.1: {}
 
   valibot@0.35.0: {}
 
@@ -7284,22 +6711,18 @@ snapshots:
     dependencies:
       spdx-correct: 3.2.0
       spdx-expression-parse: 3.0.1
-    optional: true
 
-  vary@1.1.2:
-    optional: true
+  vary@1.1.2: {}
 
   vfile-message@4.0.2:
     dependencies:
       '@types/unist': 3.0.3
       unist-util-stringify-position: 4.0.0
-    optional: true
 
   vfile@6.0.3:
     dependencies:
       '@types/unist': 3.0.3
       vfile-message: 4.0.2
-    optional: true
 
   vite-node@2.1.4(@types/node@22.8.4):
     dependencies:
@@ -7317,7 +6740,6 @@ snapshots:
       - sugarss
       - supports-color
       - terser
-    optional: true
 
   vite@5.4.10(@types/node@22.8.4):
     dependencies:
@@ -7327,7 +6749,6 @@ snapshots:
     optionalDependencies:
       '@types/node': 22.8.4
       fsevents: 2.3.3
-    optional: true
 
   vitest@2.1.4(@types/node@22.8.4)(@vitest/ui@2.1.4):
     dependencies:
@@ -7364,16 +6785,13 @@ snapshots:
       - sugarss
       - supports-color
       - terser
-    optional: true
 
-  webidl-conversions@3.0.1:
-    optional: true
+  webidl-conversions@3.0.1: {}
 
   whatwg-url@5.0.0:
     dependencies:
       tr46: 0.0.3
       webidl-conversions: 3.0.1
-    optional: true
 
   which-boxed-primitive@1.0.2:
     dependencies:
@@ -7382,10 +6800,8 @@ snapshots:
       is-number-object: 1.0.7
       is-string: 1.0.7
       is-symbol: 1.0.4
-    optional: true
 
-  which-module@2.0.1:
-    optional: true
+  which-module@2.0.1: {}
 
   which-typed-array@1.1.15:
     dependencies:
@@ -7394,23 +6810,19 @@ snapshots:
       for-each: 0.3.3
       gopd: 1.0.1
       has-tostringtag: 1.0.2
-    optional: true
 
   which@2.0.2:
     dependencies:
       isexe: 2.0.0
-    optional: true
 
   why-is-node-running@2.3.0:
     dependencies:
       siginfo: 2.0.0
       stackback: 0.0.2
-    optional: true
 
   widest-line@4.0.1:
     dependencies:
       string-width: 5.1.2
-    optional: true
 
   wordwrap@1.0.0: {}
 
@@ -7418,57 +6830,45 @@ snapshots:
     dependencies:
       reduce-flatten: 2.0.0
       typical: 5.2.0
-    optional: true
 
   wrap-ansi@6.2.0:
     dependencies:
       ansi-styles: 4.3.0
       string-width: 4.2.3
       strip-ansi: 6.0.1
-    optional: true
 
   wrap-ansi@7.0.0:
     dependencies:
       ansi-styles: 4.3.0
       string-width: 4.2.3
       strip-ansi: 6.0.1
-    optional: true
 
   wrap-ansi@8.1.0:
     dependencies:
       ansi-styles: 6.2.1
       string-width: 5.1.2
       strip-ansi: 7.1.0
-    optional: true
 
   wrappy@1.0.2: {}
 
-  xtend@4.0.2:
-    optional: true
+  xtend@4.0.2: {}
 
-  y18n@4.0.3:
-    optional: true
+  y18n@4.0.3: {}
 
-  y18n@5.0.8:
-    optional: true
+  y18n@5.0.8: {}
 
-  yallist@4.0.0:
-    optional: true
+  yallist@4.0.0: {}
 
-  yaml@1.10.2:
-    optional: true
+  yaml@1.10.2: {}
 
-  yaml@2.6.0:
-    optional: true
+  yaml@2.6.0: {}
 
   yargs-parser@18.1.3:
     dependencies:
       camelcase: 5.3.1
       decamelize: 1.2.0
-    optional: true
 
-  yargs-parser@20.2.9:
-    optional: true
+  yargs-parser@20.2.9: {}
 
   yargs@15.4.1:
     dependencies:
@@ -7483,7 +6883,6 @@ snapshots:
       which-module: 2.0.1
       y18n: 4.0.3
       yargs-parser: 18.1.3
-    optional: true
 
   yargs@16.2.0:
     dependencies:
@@ -7494,14 +6893,11 @@ snapshots:
       string-width: 4.2.3
       y18n: 5.0.8
       yargs-parser: 20.2.9
-    optional: true
 
-  yn@3.1.1:
-    optional: true
+  yn@3.1.1: {}
 
   yocto-queue@1.0.0: {}
 
   zimmerframe@1.1.2: {}
 
-  zwitch@2.0.4:
-    optional: true
+  zwitch@2.0.4: {}


### PR DESCRIPTION
This PR moves all the `optionalDependencies` to `devDependencies`. They are all only used within the project, and not necessary for any users of the package, so I assume it was just a misunderstanding of what `optionalDependencies` are.

`optionalDependencies` behave like regular `dependencies`, they are installed when the package is installed. The only difference is that when `optionalDependencies` fail to install for whatever reason, the package manager will ignore that failure and happily move on.

The most common case for `optionalDependencies` is something like `esbuild` with arch-specific binaries. It has `optionalDependencies` for all the arch-specific builds of `esbuild`, like `@esbuild/darwin-arm64` and `@esbuild/win32-x64`. That way, when a user installs `esbuild`, the package manager will try to install all the arch-specific packages, but _all but one will fail to install_, only the package that matches the machine's arch will succeed - and that's perfectly fine.

https://github.com/evanw/esbuild/blob/main/npm/esbuild/package.json#L20-L45

(the diff might look weird, all I did was move all `optionalDependencies` up to `devDependencies`, ensuring they are all still sorted alphabetically)
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>0.4.1--canary.102.11623411756.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install svelte-ast-print@0.4.1--canary.102.11623411756.0
  # or 
  yarn add svelte-ast-print@0.4.1--canary.102.11623411756.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
