### PR TITLE
fix: Auto-identation inside `TemplateLiteral`

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,11 +4,7 @@
 	"version": "0.4.1",
 	"type": "module",
 	"description": "Print Svelte AST nodes as a string. Aka parse in reverse.",
-	"keywords": [
-		"svelte",
-		"ast",
-		"print"
-	],
+	"keywords": ["svelte", "ast", "print"],
 	"license": "MIT",
 	"author": {
 		"name": "Mateusz Kadlubowski",
@@ -38,10 +34,7 @@
 	"engines": {
 		"node": ">=18"
 	},
-	"files": [
-		"src/",
-		"types/"
-	],
+	"files": ["src/", "types/"],
 	"imports": {
 		"#tests/*": {
 			"types": "./tests/*.ts",

--- a/src/mod.js
+++ b/src/mod.js
@@ -195,10 +195,15 @@ class Printer {
 		if (skip_indent) this.#output += code;
 		else {
 			code = code.replace(/^(?=.+)/gm, this.#indent);
-			const rex = /`[^`].*[^`]*`/g;
-			this.#output += code.replace(rex, (match) => {
-				return match.replace(new RegExp(this.#indent, "g"), "");
-			});
+			this.#output += code.replace(
+				// NOTE: This temporary solution is supposed to remove auto-indentation from the content inside
+				// `TemplateLiteral`.
+				// Reference: https://github.com/storybookjs/addon-svelte-csf/issues/227
+				/`[^`].*[^`]*`/g,
+				(match) => {
+					return match.replace(new RegExp(this.#indent, "g"), "");
+				},
+			);
 		}
 	}
 

--- a/tests/nodes/root.test.ts
+++ b/tests/nodes/root.test.ts
@@ -288,4 +288,37 @@ describe("Root", () => {
 			<Story name="Default" />"
 		`);
 	});
+
+	it("template literals indentation is left untouched", ({ expect }) => {
+		const code = `
+			<script>
+				const text = \`
+I am just a story.
+Hello world.
+How are you?
+
+I am good.
+			\`;
+			console.log(text);
+			</script>
+
+			hello world
+		`;
+		const node = parse_and_extract_svelte_node<AST.Root>(code, "Root");
+		expect(print(node)).toMatchInlineSnapshot(`
+			"<script>
+				const text = \`
+			I am just a story.
+			Hello world.
+			How are you?
+
+			I am good.
+			\`;
+
+				console.log(text);
+			</script>
+
+			hello world"
+		`);
+	});
 });


### PR DESCRIPTION
Resolves storybookjs/addon-svelte-csf#227

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>0.4.2--canary.103.11707813066.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install svelte-ast-print@0.4.2--canary.103.11707813066.0
  # or 
  yarn add svelte-ast-print@0.4.2--canary.103.11707813066.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
