### PR TITLE
feat: Add support for `EachBlock` without `as` item

### DIFF
--- a/src/mod.js
+++ b/src/mod.js
@@ -911,6 +911,16 @@ class Printer {
 			 * {#each expression as name}...{/each}
 			 * ```
 			 *
+			 * @example without `as` item
+			 * ```svelte
+			 * {#each expression}...{/each}
+			 * ```
+			 *
+			 * @example without `as` item, but with index
+			 * ```svelte
+			 * {#each expression, index}...{/each}
+			 * ```
+			 *
 			 * @example with index
 			 * ```svelte
 			 * {#each expression as name, index}...{/each}
@@ -931,13 +941,15 @@ class Printer {
 			 * {#each expression as name}...{:else}...{/each}
 			 * ```
 			 */
-			EachBlock(node, context) {
+			EachBlock(node, ctx) {
 				const name = "each";
-				const { body, context: node_context, expression, fallback, index, key } = node;
-				const { state } = context;
+				const { body, context, expression, fallback, index, key } = node;
+				const { state } = ctx;
 				let content = print_es(expression).code;
-				content += " as ";
-				content += print_es(node_context).code;
+				if (context) {
+					content += " as ";
+					content += print_es(context).code;
+				}
 				if (index) {
 					content += ",";
 					content += " ";
@@ -950,10 +962,10 @@ class Printer {
 					content += ")";
 				}
 				state.#print_block_opening_tag(name, content);
-				state.#print_block_fragment(body, context);
+				state.#print_block_fragment(body, ctx);
 				if (fallback) {
 					state.#print_block_middle_tag("else");
-					state.#print_block_fragment(fallback, context);
+					state.#print_block_fragment(fallback, ctx);
 				}
 				state.#print_block_closing_tag(name);
 			},

--- a/tests/nodes/block.test.ts
+++ b/tests/nodes/block.test.ts
@@ -108,6 +108,26 @@ describe("EachBlock", () => {
 		`);
 	});
 
+	it("supports without `as` item ", ({ expect }) => {
+		const code = `
+			<div class="chess-board">
+				{#each { length: 8 }, rank}
+					{#each { length: 8 }, file}
+						<div class:black={(rank + file) % 2 === 1}></div>
+					{/each}
+				{/each}
+			</div>
+		`;
+		const node = parse_and_extract_svelte_node<AST.EachBlock>(code, "EachBlock");
+		expect(print(node)).toMatchInlineSnapshot(`
+			"{#each { length: 8 }, rank}
+				{#each { length: 8 }, file}
+					<div class:black={(rank + file) % 2 === 1} />
+				{/each}
+			{/each}"
+		`);
+	});
+
 	it("correctly prints example with index", ({ expect }) => {
 		const code = `
 			{#each items as item, i}


### PR DESCRIPTION
Closes #106
